### PR TITLE
fix: Add tree-sitter support for Ruby

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-python",
+ "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "unicode-width",
@@ -1139,6 +1140,16 @@ name = "tree-sitter-python"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ default = ["card"]
 card = ["dep:resvg"]
 
 [dependencies]
+tree-sitter-ruby = "0.23.1"
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive", "wrap_help"] }
 ignore = "0.4.26"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ dupehound scan .
   ★ = representative (kept) · dupehound scan --explain 1 shows the code
 ```
 
-The slop score is the percentage of code you could delete if every cluster kept only one copy; the largest copy is exempt and test files are excluded by default, since table-driven tests are repetitive by design. `--explain N` prints a cluster's code as proof, `--json` emits a versioned schema, `--card` writes a score card as SVG and PNG. Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java.
+The slop score is the percentage of code you could delete if every cluster kept only one copy; the largest copy is exempt and test files are excluded by default, since table-driven tests are repetitive by design. `--explain N` prints a cluster's code as proof, `--json` emits a versioned schema, `--card` writes a score card as SVG and PNG. Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby.
 
 `dupehound history` measures the slop score at monthly snapshots, reading blobs straight from the object database (no checkouts), and reports when duplication took off:
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -51,7 +51,7 @@ impl Lang {
             Lang::Rust => "Rust",
             Lang::Go => "Go",
             Lang::Java => "Java",
-            Lang::Ruby=>"Ruby",
+            Lang::Ruby => "Ruby",
         }
     }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -11,10 +11,11 @@ pub enum Lang {
     Rust,
     Go,
     Java,
+    Ruby,
 }
 
 #[cfg(test)]
-pub const ALL: [Lang; 7] = [
+pub const ALL: [Lang; 8] = [
     Lang::Typescript,
     Lang::Tsx,
     Lang::Javascript,
@@ -22,6 +23,7 @@ pub const ALL: [Lang; 7] = [
     Lang::Rust,
     Lang::Go,
     Lang::Java,
+    Lang::Ruby,
 ];
 
 impl Lang {
@@ -35,6 +37,7 @@ impl Lang {
             "rs" => Some(Lang::Rust),
             "go" => Some(Lang::Go),
             "java" => Some(Lang::Java),
+            "rb" => Some(Lang::Ruby),
             _ => None,
         }
     }
@@ -48,6 +51,7 @@ impl Lang {
             Lang::Rust => "Rust",
             Lang::Go => "Go",
             Lang::Java => "Java",
+            Lang::Ruby=>"Ruby",
         }
     }
 
@@ -60,6 +64,7 @@ impl Lang {
             Lang::Rust => tree_sitter_rust::LANGUAGE.into(),
             Lang::Go => tree_sitter_go::LANGUAGE.into(),
             Lang::Java => tree_sitter_java::LANGUAGE.into(),
+            Lang::Ruby => tree_sitter_ruby::LANGUAGE.into(),
         }
     }
 
@@ -71,11 +76,12 @@ impl Lang {
             Lang::Rust => include_str!("queries/rust.scm"),
             Lang::Go => include_str!("queries/go.scm"),
             Lang::Java => include_str!("queries/java.scm"),
+            Lang::Ruby => include_str!("queries/ruby.scm"),
         }
     }
 
     pub fn query(self) -> &'static Query {
-        static QUERIES: [OnceLock<Query>; 7] = [const { OnceLock::new() }; 7];
+        static QUERIES: [OnceLock<Query>; 8] = [const { OnceLock::new() }; 8];
         QUERIES[self as usize].get_or_init(|| {
             Query::new(&self.language(), self.query_source())
                 .unwrap_or_else(|e| panic!("bad {} query: {e}", self.name()))

--- a/src/lang/queries/ruby.scm
+++ b/src/lang/queries/ruby.scm
@@ -1,0 +1,11 @@
+;; src/lang/queries/ruby.scm
+
+(method
+  name: (_) @name
+  (body_statement) @body
+) @func
+
+(singleton_method
+  name: (_) @name
+  (body_statement) @body
+) @func

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -108,7 +108,7 @@ pub fn discover(root: &Path, config: &Config) -> Result<Vec<DiscoveredFile>> {
     if files.is_empty() {
         anyhow::bail!(
             "no supported source files found under {} \
-             (supported: .ts .tsx .js .jsx .py .rs .go .java)",
+             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb)",
             root.display()
         );
     }
@@ -155,6 +155,8 @@ pub fn is_test_path(rel: &str) -> bool {
         || file.ends_with("test.java")
         || file.ends_with("tests.java")
         || file.starts_with("conftest.")
+        || file.ends_with("_spec.rb")
+        || file.ends_with("_test.rb")
     {
         return true;
     }
@@ -221,6 +223,8 @@ mod tests {
         assert!(is_test_path("src/components/Button.test.tsx"));
         assert!(!is_test_path("src/api/testimonials.ts"));
         assert!(!is_test_path("src/contest.rs"));
+        assert!(is_test_path("spec/user_spec.rb"));
+        assert!(is_test_path("test/auth_test.rb"));
     }
 
     #[test]

--- a/tests/languages.rs
+++ b/tests/languages.rs
@@ -151,7 +151,39 @@ function checkCredential(jwt, key) {
 module.exports = { checkCredential };
 "#,
 };
-
+const RUBY: Fixture = Fixture {
+    file_a: "auth.rb",
+    file_b: "session.rb",
+    names: ("validate_token", "check_credential"),
+    src_a: r#"
+def validate_token(token, secret)
+    parts = token.split(".")
+    if parts.length != 3
+        return { valid: false, reason: "malformed" }
+    end
+    payload = JSON.parse(Base64.decode64(parts[1]))
+    if payload["exp"] < Time.now.to_i
+        return { valid: false, reason: "expired" }
+    end
+    signature = sign(parts[0] + "." + parts[1], secret)
+    return { valid: signature == parts[2], reason: "checked" }
+end
+"#,
+    src_b: r#"
+def check_credential(jwt, key)
+    chunks = jwt.split(".")
+    if chunks.length != 3
+        return { valid: false, reason: "bad" }
+    end
+    body = JSON.parse(Base64.decode64(chunks[1]))
+    if body["exp"] < Time.now.to_i
+        return { valid: false, reason: "old" }
+    end
+    sig = sign(chunks[0] + "." + chunks[1], key)
+    return { valid: sig == chunks[2], reason: "done" }
+end
+"#,
+};
 const RUST: Fixture = Fixture {
     file_a: "parser.rs",
     file_b: "lexer.rs",
@@ -268,6 +300,10 @@ fn java_renamed_clone_is_detected() {
 #[test]
 fn javascript_renamed_clone_is_detected() {
     assert_clone_pair_detected(&JAVASCRIPT);
+}
+#[test]
+fn ruby_renamed_clone_is_detected() {
+    assert_clone_pair_detected(&RUBY);
 }
 
 #[test]


### PR DESCRIPTION
fixes #3 

-Added tree-sitter-ruby & wired src/lang/mod.rs
-Added ruby.scm AST queries
-Added test fixtures in tests/languages.rs
-All tests passing 