### PR TITLE
docs: technical hero header and scannable Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ brew install rafaelpta/dupehound/dupehound
 
 ## Usage
 
+### `scan`
+
 `dupehound scan [path]` ranks duplicate clusters by deletable lines:
 
 ```
@@ -68,6 +70,8 @@ $ dupehound scan .
 
 The slop score is the percentage of code you could delete if every cluster kept only one copy; the largest copy is exempt and test files are excluded by default, since table-driven tests are repetitive by design. `--explain N` prints a cluster's code as proof, `--json` emits a versioned schema, `--card` writes a score card as SVG and PNG. Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP.
 
+### `history`
+
 `dupehound history` measures the slop score at monthly snapshots, reading blobs straight from the object database (no checkouts), and reports when duplication took off:
 
 ```
@@ -82,6 +86,8 @@ The slop score is the percentage of code you could delete if every cluster kept 
   current slop score: 36.1% (grade F)
   duplication went from ~0 to 36.1% since 2025-05
 ```
+
+### `check`
 
 `dupehound check` gates CI and pre-commit. It indexes the codebase at the base revision and probes only the functions a change adds or touches. Moved functions and in-place edits don't fire. Exit codes: 0 clean, 1 findings, 2 error.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,27 @@
-# dupehound
-
 <p align="center">
-  <a href="https://github.com/Rafaelpta/dupehound/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Rafaelpta/dupehound/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/Rafaelpta/dupehound?color=blue"></a>
+  <img src="assets/hound.png" alt="dupehound" width="200">
 </p>
 
+<h1 align="center">dupehound</h1>
+
+<p align="center">Finds functions duplicated by AI, even after every identifier is renamed.</p>
+
 <p align="center">
-  <img src="assets/hound.png" alt="dupehound" width="240">
+  <img alt="Platform" src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue">
+  <a href="https://github.com/Rafaelpta/dupehound/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Rafaelpta/dupehound/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/Rafaelpta/dupehound?color=blue"></a>
+  <a href="https://github.com/Rafaelpta/dupehound/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/Rafaelpta/dupehound"></a>
 </p>
 
 dupehound is a duplicate-code detector built for codebases where agents write most of the code. It finds functions that exist more than once, even after every identifier and literal has been renamed, because it fingerprints the structure of the code instead of its text.
 
-dupehound runs three commands: `scan` reports every duplicate cluster and a repo-level slop score, `history` charts duplication across the git log and pinpoints when it took off, and `check` fails CI when a change duplicates code that already exists, naming the original to reuse. Everything runs locally and deterministically: no network, no API keys, no machine learning.
+| Command | What it does |
+|---------|--------------|
+| `scan` | reports every duplicate cluster and a repo-level slop score |
+| `history` | charts duplication across the git log and pinpoints when it took off |
+| `check` | fails CI when a change duplicates code that already exists, naming the original to reuse |
+
+Everything runs locally and deterministically: no network, no API keys, no machine learning.
 
 <p align="center">
   <img src="assets/pipeline.svg" alt="The pipeline: discover files, fingerprint every function via tree-sitter parsing and winnowing, match through an inverted index, report" width="900">


### PR DESCRIPTION
Add a centered hero (mascot, title, technical tagline, badge row), a three-row command table at the top, and split Usage into scan/history/check subsections. Drops the marketing-style language links and keeps the Tailscale register.