### PR TITLE
feat(lang): add C# support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "thiserror",
  "tree-sitter",
  "tree-sitter-c",
+ "tree-sitter-c-sharp",
  "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-java",
@@ -1110,6 +1111,16 @@ name = "tree-sitter-c"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tree-sitter-typescript = "0.23.2"
 tree-sitter-swift = "0.7.3"
 tree-sitter-php = "0.22.2"
 unicode-width = "0.2.2"
+tree-sitter-c-sharp = "0.23.5"
 
 [dev-dependencies]
 insta = { version = "1.47.2", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p align="center">Finds functions duplicated by AI, even after every identifier is renamed.</p>
 
 <p align="center">
+  <a href="./LICENSE"><img alt="Open Source" src="https://img.shields.io/badge/open%20source-100%25-success"></a>
   <img alt="Platform" src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue">
   <a href="https://github.com/Rafaelpta/dupehound/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Rafaelpta/dupehound/actions/workflows/ci.yml/badge.svg"></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/Rafaelpta/dupehound?color=blue"></a>
@@ -61,7 +62,7 @@ The slop score is the percentage of code you could delete if every cluster kept 
 <li><code>--card</code> writes a score card as SVG and PNG</li>
 </ul>
 
-Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP.
+Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#.
 
 ### `history`
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -16,10 +16,11 @@ pub enum Lang {
     C,
     Cpp,
     Php,
+    Csharp,
 }
 
 #[cfg(test)]
-pub const ALL: [Lang; 12] = [
+pub const ALL: [Lang; 13] = [
     Lang::Typescript,
     Lang::Tsx,
     Lang::Javascript,
@@ -32,6 +33,7 @@ pub const ALL: [Lang; 12] = [
     Lang::C,
     Lang::Cpp,
     Lang::Php,
+    Lang::Csharp,
 ];
 
 impl Lang {
@@ -50,6 +52,7 @@ impl Lang {
             "c" | "h" => Some(Lang::C),
             "cc" | "cpp" | "cxx" | "c++" | "hpp" | "hh" | "hxx" => Some(Lang::Cpp),
             "php" => Some(Lang::Php),
+            "cs" => Some(Lang::Csharp),
             _ => None,
         }
     }
@@ -68,6 +71,7 @@ impl Lang {
             Lang::C => "C",
             Lang::Cpp => "C++",
             Lang::Php => "Php",
+            Lang::Csharp => "C#",
         }
     }
 
@@ -85,6 +89,7 @@ impl Lang {
             Lang::Swift => tree_sitter_swift::LANGUAGE.into(),
             Lang::C => tree_sitter_c::LANGUAGE.into(),
             Lang::Cpp => tree_sitter_cpp::LANGUAGE.into(),
+            Lang::Csharp => tree_sitter_c_sharp::LANGUAGE.into(),
         }
     }
 
@@ -101,11 +106,12 @@ impl Lang {
             Lang::C => include_str!("queries/c.scm"),
             Lang::Cpp => include_str!("queries/cpp.scm"),
             Lang::Php => include_str!("queries/php.scm"),
+            Lang::Csharp => include_str!("queries/csharp.scm"),
         }
     }
 
     pub fn query(self) -> &'static Query {
-        static QUERIES: [OnceLock<Query>; 12] = [const { OnceLock::new() }; 12];
+        static QUERIES: [OnceLock<Query>; 13] = [const { OnceLock::new() }; 13];
         QUERIES[self as usize].get_or_init(|| {
             Query::new(&self.language(), self.query_source())
                 .unwrap_or_else(|e| panic!("bad {} query: {e}", self.name()))

--- a/src/lang/queries/csharp.scm
+++ b/src/lang/queries/csharp.scm
@@ -1,0 +1,11 @@
+(method_declaration
+  name: (identifier) @name
+  body: (block) @body) @func
+
+(constructor_declaration
+  name: (identifier) @name
+  body: (block) @body) @func
+
+(local_function_statement
+  name: (identifier) @name
+  body: (block) @body) @func

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -108,7 +108,7 @@ pub fn discover(root: &Path, config: &Config) -> Result<Vec<DiscoveredFile>> {
     if files.is_empty() {
         anyhow::bail!(
             "no supported source files found under {} \
-             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb .swift .c .h .cpp .cc .hpp .php)",
+             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb .swift .c .h .cpp .cc .hpp .php .cs)",
             root.display()
         );
     }

--- a/tests/languages.rs
+++ b/tests/languages.rs
@@ -47,6 +47,56 @@ function calculateAmount($rows, $vat) {
 "#,
 };
 
+const CSHARP: Fixture = Fixture {
+    file_a: "Billing.cs",
+    file_b: "Invoices.cs",
+    names: ("ComputeTotal", "CalculateAmount"),
+    src_a: r#"
+using System.Collections.Generic;
+
+class Billing
+{
+    public static decimal ComputeTotal(List<Dictionary<string, decimal>> items, decimal taxRate)
+    {
+        decimal subtotal = 0m;
+        foreach (var item in items)
+        {
+            decimal price = item["price"] * item["qty"];
+            if (item.ContainsKey("discount"))
+            {
+                price = price * (1m - item["discount"]);
+            }
+            subtotal += price;
+        }
+        decimal tax = subtotal * taxRate;
+        return subtotal + tax;
+    }
+}
+"#,
+    src_b: r#"
+using System.Collections.Generic;
+
+class Invoices
+{
+    public static decimal CalculateAmount(List<Dictionary<string, decimal>> rows, decimal vat)
+    {
+        decimal baseAmount = 0m;
+        foreach (var row in rows)
+        {
+            decimal cost = row["price"] * row["qty"];
+            if (row.ContainsKey("discount"))
+            {
+                cost = cost * (1m - row["discount"]);
+            }
+            baseAmount += cost;
+        }
+        decimal extra = baseAmount * vat;
+        return baseAmount + extra;
+    }
+}
+"#,
+};
+
 const PYTHON: Fixture = Fixture {
     file_a: "billing.py",
     file_b: "invoices.py",
@@ -546,6 +596,10 @@ fn cpp_renamed_clone_is_detected() {
 #[test]
 fn php_renamed_clone_is_detected() {
     assert_clone_pair_detected(&PHP);
+}
+#[test]
+fn csharp_renamed_clone_is_detected() {
+    assert_clone_pair_detected(&CSHARP);
 }
 #[test]
 fn c_pointer_return_clone_is_detected() {


### PR DESCRIPTION
Adds C# to the supported languages.

## What changed
- `tree-sitter-c-sharp` grammar added to Cargo.toml
- `Csharp` variant wired into `Lang` (extension `.cs`, name, language, query)
- new `src/lang/queries/csharp.scm` capturing methods, constructors and local functions
- `.cs` added to the walker's supported-extensions message
- renamed-clone fixture and test in `tests/languages.rs`
- C# added to the README language list

## Verification
- `cargo test` passes, including the new `csharp_renamed_clone_is_detected` fixture and the `abi_in_supported_range` / `queries_compile_for_every_language` checks
- `cargo fmt --check` and `cargo clippy --all-targets` are clean
- smoke test: `dupehound scan` on a pair of renamed C# files reports one 100% cluster

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)