### PR TITLE
feat(scan): experimental --include-classes for C# class-shape dedup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The slop score is the percentage of code you could delete if every cluster kept 
 <li><code>--explain N</code> prints a cluster's code as proof</li>
 <li><code>--json</code> emits a versioned schema</li>
 <li><code>--card</code> writes a score card as SVG and PNG</li>
+<li><code>--include-classes</code> flags C# classes with near-duplicate property and method signatures (experimental, opt-in, never affects the slop score)</li>
 </ul>
 
 Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,6 +80,11 @@ pub struct ScanArgs {
     /// Also write a shareable score card (dupehound-card.svg/.png)
     #[arg(long)]
     pub card: bool,
+
+    /// Experimental: also report C# classes whose property/method signatures
+    /// are near-duplicates (separate from the function clusters and the score)
+    #[arg(long)]
+    pub include_classes: bool,
 }
 
 #[derive(Args)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,8 @@ pub struct Config {
     pub default_excludes: bool,
     pub tests: TestPolicy,
     pub json: bool,
+    /// Experimental: also run the C# "class shape" track (scan only).
+    pub include_classes: bool,
 }
 
 impl Config {
@@ -54,6 +56,7 @@ impl Config {
             default_excludes: !common.no_default_excludes,
             tests,
             json: common.json,
+            include_classes: false,
         }
     }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -5,9 +5,11 @@ use crate::config::{KGRAM, WINDOW};
 use crate::fingerprint::winnow;
 use crate::lang::Lang;
 use crate::normalize::{normalize, significant_lines};
+use rustc_hash::FxHasher;
 use std::cell::RefCell;
+use std::hash::{Hash, Hasher};
 use streaming_iterator::StreamingIterator;
-use tree_sitter::{Parser, QueryCursor};
+use tree_sitter::{Node, Parser, QueryCursor};
 
 /// One function (or method) found in a file. The unit of duplicate
 /// comparison is the *body*, so signatures, imports and license headers
@@ -147,6 +149,149 @@ pub fn analyze_source(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Experimental "class shape" extraction (opt-in via `--include-classes`).
+//
+// Instead of fingerprinting a function body, this treats a *type* as a set of
+// member signatures: each property/field/method signature (bodies dropped,
+// identifiers KEPT) is hashed, and the class's "fingerprints" are that set.
+// Two classes then cluster when they share most member signatures — which is
+// the "near-duplicate model class" smell. This is a separate track from the
+// function-body pipeline and never feeds the slop score.
+// ---------------------------------------------------------------------------
+
+/// Sub-nodes that mark the start of a member's *body* (dropped from its
+/// signature): method blocks, property accessor lists, expression bodies.
+const SHAPE_BODY_KINDS: [&str; 3] = ["block", "accessor_list", "arrow_expression_clause"];
+
+/// A type needs at least this many distinct member signatures to be compared.
+/// Below it the shape is too generic to mean anything (noise control).
+const SHAPE_MIN_MEMBERS: usize = 3;
+
+/// True for declaration_list children that are real members (property, field,
+/// method, constructor, event, indexer, operator) rather than nested types.
+fn is_shape_member(kind: &str) -> bool {
+    kind.ends_with("_declaration")
+        && !matches!(
+            kind,
+            "class_declaration"
+                | "struct_declaration"
+                | "record_declaration"
+                | "interface_declaration"
+                | "enum_declaration"
+                | "delegate_declaration"
+                | "namespace_declaration"
+        )
+}
+
+/// A single member's signature: its source text up to its body (block /
+/// accessors / arrow), trailing punctuation stripped and whitespace collapsed.
+/// Identifiers and types are kept, so `int Age` and `string Name` are distinct.
+fn member_signature(member: Node, src: &str) -> Option<String> {
+    let mut end = member.end_byte();
+    let mut cur = member.walk();
+    for child in member.children(&mut cur) {
+        if SHAPE_BODY_KINDS.contains(&child.kind()) {
+            end = child.start_byte();
+            break;
+        }
+    }
+    let raw = src.get(member.start_byte()..end)?;
+    let trimmed = raw.trim().trim_end_matches([';', '{']).trim_end();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.split_whitespace().collect::<Vec<_>>().join(" "))
+}
+
+/// Extract one class-shape unit per type declaration whose member-signature set
+/// is large enough to be meaningful. Returns plain `FunctionUnit`s (kept in
+/// their own vector by the caller) so the existing index/cluster pipeline can
+/// compare them by Jaccard over the member-signature set.
+pub fn extract_class_shapes(
+    file: u32,
+    lang: Lang,
+    src: &str,
+    file_is_test: bool,
+) -> Vec<FunctionUnit> {
+    let Some(query) = lang.shape_query() else {
+        return Vec::new();
+    };
+    let parsed = PARSER.with(|p| {
+        let mut parser = p.borrow_mut();
+        parser.set_language(&lang.language()).ok()?;
+        parser.parse(src, None)
+    });
+    let Some(tree) = parsed else {
+        return Vec::new();
+    };
+    let root = tree.root_node();
+
+    let name_idx = query.capture_index_for_name("name");
+    let body_idx = query.capture_index_for_name("body");
+    let func_idx = query.capture_index_for_name("func");
+
+    let mut units = Vec::new();
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, root, src.as_bytes());
+    while let Some(m) = matches.next() {
+        let mut name = None;
+        let mut body = None;
+        let mut func = None;
+        for cap in m.captures {
+            if Some(cap.index) == name_idx {
+                name = Some(cap.node);
+            } else if Some(cap.index) == body_idx {
+                body = Some(cap.node);
+            } else if Some(cap.index) == func_idx {
+                func = Some(cap.node);
+            }
+        }
+        let (Some(body), Some(func)) = (body, func) else {
+            continue;
+        };
+
+        let mut fingerprints: Vec<u64> = Vec::new();
+        let mut walker = body.walk();
+        for member in body.named_children(&mut walker) {
+            if !is_shape_member(member.kind()) {
+                continue;
+            }
+            if let Some(sig) = member_signature(member, src) {
+                let mut h = FxHasher::default();
+                sig.hash(&mut h);
+                fingerprints.push(h.finish());
+            }
+        }
+        fingerprints.sort_unstable();
+        fingerprints.dedup();
+        if fingerprints.len() < SHAPE_MIN_MEMBERS {
+            continue;
+        }
+
+        let name = name
+            .and_then(|n| n.utf8_text(src.as_bytes()).ok())
+            .unwrap_or("<anonymous>")
+            .to_string();
+        // sig_lines doubles as the member count here: it drives representative
+        // choice (most members wins) and the report's per-class member tally.
+        let member_count = fingerprints.len() as u32;
+        units.push(FunctionUnit {
+            file,
+            lang,
+            name,
+            start_line: func.start_position().row as u32 + 1,
+            end_line: func.end_position().row as u32 + 1,
+            start_byte: func.start_byte() as u32,
+            end_byte: func.end_byte() as u32,
+            sig_lines: member_count,
+            fingerprints,
+            is_test: file_is_test,
+        });
+    }
+    units
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -226,6 +371,67 @@ function describeUser(user: { name: string; age: number }): string {
         let fa1 = analyze_source(0, Lang::Typescript, without, 5, false).unwrap();
         let fa2 = analyze_source(0, Lang::Typescript, with, 5, false).unwrap();
         assert_eq!(fa1.functions[0].fingerprints, fa2.functions[0].fingerprints);
+    }
+
+    const CS_CLASSES: &str = r#"
+public class Customer {
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Email { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+public class CustomerRecord {
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Email { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+public class Invoice {
+    public int InvoiceNumber { get; set; }
+    public decimal Amount { get; set; }
+    public string Currency { get; set; }
+}
+
+public class Tiny {
+    public int X { get; set; }
+}
+"#;
+
+    #[test]
+    fn class_shapes_extracts_only_non_trivial_types() {
+        let shapes = extract_class_shapes(0, Lang::Csharp, CS_CLASSES, false);
+        // Customer, CustomerRecord and Invoice qualify; Tiny (1 member) is below
+        // the member floor and is dropped.
+        let names: Vec<&str> = shapes.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["Customer", "CustomerRecord", "Invoice"]);
+    }
+
+    #[test]
+    fn near_duplicate_classes_share_signatures() {
+        let shapes = extract_class_shapes(0, Lang::Csharp, CS_CLASSES, false);
+        let by = |n: &str| shapes.iter().find(|s| s.name == n).unwrap();
+        // Same property set, different class name -> identical signature set.
+        let j = crate::fingerprint::jaccard(
+            &by("Customer").fingerprints,
+            &by("CustomerRecord").fingerprints,
+        );
+        assert!((j - 1.0).abs() < 1e-9, "expected identical shapes, got {j}");
+    }
+
+    #[test]
+    fn unrelated_classes_do_not_share_signatures() {
+        let shapes = extract_class_shapes(0, Lang::Csharp, CS_CLASSES, false);
+        let by = |n: &str| shapes.iter().find(|s| s.name == n).unwrap();
+        let j =
+            crate::fingerprint::jaccard(&by("Customer").fingerprints, &by("Invoice").fingerprints);
+        assert!(j < 0.1, "unrelated classes scored {j}");
+    }
+
+    #[test]
+    fn non_csharp_has_no_shape_query() {
+        assert!(extract_class_shapes(0, Lang::Typescript, "class Foo {}", false).is_empty());
     }
 
     #[test]

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -117,6 +117,24 @@ impl Lang {
                 .unwrap_or_else(|e| panic!("bad {} query: {e}", self.name()))
         })
     }
+
+    /// Experimental: query capturing type declarations for the opt-in
+    /// `--include-classes` "class shape" mode. Only C# is wired up so far.
+    fn shape_query_source(self) -> Option<&'static str> {
+        match self {
+            Lang::Csharp => Some(include_str!("queries/csharp_shape.scm")),
+            _ => None,
+        }
+    }
+
+    pub fn shape_query(self) -> Option<&'static Query> {
+        let src = self.shape_query_source()?;
+        static SHAPE_QUERIES: [OnceLock<Query>; 13] = [const { OnceLock::new() }; 13];
+        Some(SHAPE_QUERIES[self as usize].get_or_init(|| {
+            Query::new(&self.language(), src)
+                .unwrap_or_else(|e| panic!("bad {} shape query: {e}", self.name()))
+        }))
+    }
 }
 
 /// What a leaf token contributes to the normalized stream.

--- a/src/lang/queries/csharp_shape.scm
+++ b/src/lang/queries/csharp_shape.scm
@@ -1,0 +1,14 @@
+; Experimental "class shape" capture: a type declaration and its member list.
+; The body is walked in extract.rs to build a set of member signatures
+; (property/field/method signatures, bodies dropped), not winnowed.
+(class_declaration
+  name: (identifier) @name
+  body: (declaration_list) @body) @func
+
+(struct_declaration
+  name: (identifier) @name
+  body: (declaration_list) @body) @func
+
+(record_declaration
+  name: (identifier) @name
+  body: (declaration_list) @body) @func

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -15,6 +15,10 @@ pub struct Report {
     pub stats: Stats,
     pub score: ScoreOut,
     pub clusters: Vec<ClusterOut>,
+    /// Experimental class-shape clusters (`--include-classes`). Omitted from
+    /// JSON when empty so the default output is byte-for-byte unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub class_shapes: Vec<ClusterOut>,
 }
 
 #[derive(Serialize)]
@@ -61,21 +65,18 @@ pub struct MemberOut {
     pub test: bool,
 }
 
-pub fn build(
-    root: &str,
-    file_names: &[String],
-    functions: &[FunctionUnit],
+/// Map internal clusters to their serializable form. Shared by the function
+/// clusters and the experimental class-shape clusters.
+pub fn clusters_out(
     clusters: &[Cluster],
-    score: &Score,
-    stats: Stats,
-) -> Report {
-    // Under TestPolicy::Skip test files were never scanned; under FlagOnly
-    // test clusters are shown (labeled) but excluded from the score.
-    let clusters_out = clusters
+    functions: &[FunctionUnit],
+    file_names: &[String],
+) -> Vec<ClusterOut> {
+    clusters
         .iter()
         .enumerate()
         .map(|(i, c)| {
-            let members: Vec<MemberOut> = c
+            let mut members: Vec<MemberOut> = c
                 .members
                 .iter()
                 .map(|m| {
@@ -92,7 +93,6 @@ pub fn build(
                     }
                 })
                 .collect();
-            let mut members = members;
             if let Some(first) = members.first_mut() {
                 first.representative = true;
             }
@@ -111,7 +111,20 @@ pub fn build(
                 members,
             }
         })
-        .collect();
+        .collect()
+}
+
+pub fn build(
+    root: &str,
+    file_names: &[String],
+    functions: &[FunctionUnit],
+    clusters: &[Cluster],
+    score: &Score,
+    stats: Stats,
+) -> Report {
+    // Under TestPolicy::Skip test files were never scanned; under FlagOnly
+    // test clusters are shown (labeled) but excluded from the score.
+    let clusters_out = clusters_out(clusters, functions, file_names);
 
     Report {
         schema_version: JSON_SCHEMA_VERSION,
@@ -123,5 +136,6 @@ pub fn build(
             deletable_lines: score.deletable_lines,
         },
         clusters: clusters_out,
+        class_shapes: Vec::new(),
     }
 }

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -42,6 +42,66 @@ pub fn render(report: &Report, all: bool) -> String {
     out
 }
 
+/// Experimental `--include-classes` section, printed after the normal report.
+/// Lists C# classes whose property/method signatures largely overlap. This is
+/// a separate finding from the function clusters and is not part of the score.
+pub fn render_shapes(report: &Report) -> String {
+    let mut out = String::new();
+    out.push('\n');
+    out.push_str(&bold("  CLASS SHAPES  "));
+    out.push_str(&dim("(experimental · --include-classes)\n"));
+    out.push_str(&dim(
+        "  types whose property/method signatures are near-duplicates\n\n",
+    ));
+
+    if report.class_shapes.is_empty() {
+        out.push_str("  No near-duplicate class shapes found.\n\n");
+        return out;
+    }
+
+    for c in &report.class_shapes {
+        let title = format!(
+            "● Shape {} ─ {} classes · {:.0}% shared signatures",
+            c.id,
+            c.copies,
+            c.similarity * 100.0,
+        );
+        out.push_str(&format!("  {}\n", bold(&title)));
+        let loc_width = c
+            .members
+            .iter()
+            .map(|m| format!("{}:{}", m.file, m.start_line).len())
+            .max()
+            .unwrap_or(0)
+            .min(58);
+        for m in &c.members {
+            let loc = truncate_left(&format!("{}:{}", m.file, m.start_line), loc_width);
+            let members = format!("{} members", m.lines);
+            if m.representative {
+                out.push_str(&format!(
+                    "    {} {loc:<loc_width$}  {}  {:>11}\n",
+                    yellow("★"),
+                    bold(&m.name),
+                    members,
+                ));
+            } else {
+                let pct = format!("{:>3.0}%", m.similarity * 100.0);
+                out.push_str(&format!(
+                    "      {loc:<loc_width$}  {}  {:>11}   {} shared\n",
+                    m.name,
+                    members,
+                    bold(&pct),
+                ));
+            }
+        }
+        out.push('\n');
+    }
+    out.push_str(&dim(
+        "  experimental: classes are matched by shared member signatures, not bodies\n",
+    ));
+    out
+}
+
 fn header(out: &mut String, r: &Report) {
     out.push('\n');
     out.push_str(&dim(&format!(

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -23,7 +23,8 @@ pub struct ScanOutput {
 }
 
 pub fn run(args: ScanArgs) -> Result<i32> {
-    let config = Config::from_common(&args.common, DEFAULT_SCAN_THRESHOLD);
+    let mut config = Config::from_common(&args.common, DEFAULT_SCAN_THRESHOLD);
+    config.include_classes = args.include_classes;
     let output = scan_path(&args.path, &config)?;
 
     if let Some(cluster_id) = args.explain {
@@ -35,6 +36,9 @@ pub fn run(args: ScanArgs) -> Result<i32> {
         println!("{}", serde_json::to_string_pretty(&output.report)?);
     } else {
         print!("{}", terminal::render(&output.report, args.all));
+        if config.include_classes {
+            print!("{}", terminal::render_shapes(&output.report));
+        }
     }
 
     #[cfg(feature = "card")]
@@ -64,6 +68,7 @@ pub fn scan_path(root: &Path, config: &Config) -> Result<ScanOutput> {
         rel: String,
         path: std::path::PathBuf,
         functions: Vec<FunctionUnit>,
+        shapes: Vec<FunctionUnit>,
         sig_lines: u32,
         total_lines: u32,
     }
@@ -89,10 +94,16 @@ pub fn scan_path(root: &Path, config: &Config) -> Result<ScanOutput> {
             };
             // File id is stamped after the parallel phase (stable order).
             let fa = analyze_source(0, f.lang, &content, config.min_tokens, f.is_test)?;
+            let shapes = if config.include_classes {
+                crate::extract::extract_class_shapes(0, f.lang, &content, f.is_test)
+            } else {
+                Vec::new()
+            };
             Some(FileResult {
                 rel: f.rel.clone(),
                 path: f.path.clone(),
                 functions: fa.functions,
+                shapes,
                 sig_lines: fa.sig_lines,
                 total_lines: fa.total_lines,
             })
@@ -103,13 +114,18 @@ pub fn scan_path(root: &Path, config: &Config) -> Result<ScanOutput> {
     let mut file_names = Vec::with_capacity(results.len());
     let mut file_paths = Vec::with_capacity(results.len());
     let mut functions: Vec<FunctionUnit> = Vec::new();
+    let mut shape_functions: Vec<FunctionUnit> = Vec::new();
     let mut total_lines = 0u64;
     let mut sig_lines = 0u64;
     for (i, mut r) in results.into_iter().enumerate() {
         for f in &mut r.functions {
             f.file = i as u32;
         }
+        for s in &mut r.shapes {
+            s.file = i as u32;
+        }
         functions.extend(r.functions);
+        shape_functions.extend(r.shapes);
         file_names.push(r.rel);
         file_paths.push(r.path);
         total_lines += r.total_lines as u64;
@@ -119,6 +135,15 @@ pub fn scan_path(root: &Path, config: &Config) -> Result<ScanOutput> {
     let pairs = find_pairs(&mut functions, config.threshold, MIN_SHARED_PREFILTER);
     let clusters = build_clusters(&functions, &pairs);
     let score = slop_score(&clusters, sig_lines, config.tests);
+
+    // Experimental class-shape track: its own pairs/clusters, never folded
+    // into the slop score above.
+    let shape_clusters = if config.include_classes {
+        let shape_pairs = find_pairs(&mut shape_functions, config.threshold, MIN_SHARED_PREFILTER);
+        build_clusters(&shape_functions, &shape_pairs)
+    } else {
+        Vec::new()
+    };
 
     let stats = Stats {
         files: file_names.len() as u32,
@@ -131,7 +156,7 @@ pub fn scan_path(root: &Path, config: &Config) -> Result<ScanOutput> {
         skipped_non_utf8: skipped_non_utf8.into_inner(),
     };
 
-    let report = build(
+    let mut report = build(
         &root.display().to_string(),
         &file_names,
         &functions,
@@ -139,6 +164,10 @@ pub fn scan_path(root: &Path, config: &Config) -> Result<ScanOutput> {
         &score,
         stats,
     );
+    if config.include_classes {
+        report.class_shapes =
+            crate::report::clusters_out(&shape_clusters, &shape_functions, &file_names);
+    }
 
     Ok(ScanOutput {
         report,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -270,6 +270,7 @@ mod tests {
             default_excludes: true,
             tests: crate::config::TestPolicy::FlagOnly,
             json: false,
+            include_classes: false,
         };
         let files = discover(root, &config).unwrap();
         let rels: Vec<&str> = files.iter().map(|f| f.rel.as_str()).collect();


### PR DESCRIPTION
Experimental, not for merge yet. Opening it for validation with the user who asked in #24.

## Why
#24 asks for detecting near-duplicate C# model classes: classes whose property and method signatures largely overlap, even when the logic differs. dupehound deliberately compares function bodies and ignores signatures, which is what keeps its noise low. So this is a different kind of analysis, and it ships behind a flag, off by default, until it proves useful on a real codebase.

## What this adds
- `dupehound scan <path> --include-classes` (C# only for now).
- A separate "CLASS SHAPES" section listing classes that share most of their member signatures. It is not part of the slop score.
- Without the flag, output is unchanged (JSON omits the field entirely).

## How it works
Each C# class becomes a set of member signatures (property/field/method signatures, bodies dropped, identifiers kept). Two classes cluster when they share most signatures, reusing the existing winnowing index. Types with fewer than three members are skipped as too generic.

## How to try it
1. git clone -b experiment/class-shapes <repo> && cd dupehound
2. cargo build --release
3. ./target/release/dupehound scan <your C# repo> --include-classes

## What I want to learn
- Does it surface model classes you would actually refactor?
- Is the noise low enough that you would keep the flag on?

If yes, it graduates with docs and more fixtures. If it is too noisy, it stays a draft and we learned cheaply.

Refs #24
