### PR TITLE
feat(scan): keep Rust trait-impl look-alikes out of the slop score

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ brew install rafaelpta/dupehound/dupehound
   <img src="assets/scan.png" alt="dupehound scan on the vscode source tree: 2.8 percent slop, grade A, listing the top duplicate clusters" width="880">
 </p>
 
-The slop score is the percentage of code you could delete if every cluster kept only one copy; the largest copy is exempt and test files are excluded by default, since table-driven tests are repetitive by design.
+The slop score is the percentage of code you could delete if every cluster kept only one copy; the largest copy is exempt and test files are excluded by default, since table-driven tests are repetitive by design. On Rust, trait-impl methods (`From`, `Display`, ...) are also kept out of the score, since each impl is required and cannot be merged.
 
 <ul>
 <li><code>--explain N</code> prints a cluster's code as proof</li>

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -18,6 +18,10 @@ pub struct Cluster {
     pub deletable_lines: u32,
     /// True when every member is test code.
     pub test_only: bool,
+    /// True when every member is a Rust trait-impl method (`From`, `Display`,
+    /// ...). Like `test_only`, these are kept out of the slop score: each impl
+    /// is a distinct, required implementation, not deletable duplication.
+    pub trait_impl_only: bool,
 }
 
 struct UnionFind {
@@ -94,10 +98,14 @@ pub fn build_clusters(functions: &[FunctionUnit], pairs: &[Pair]) -> Vec<Cluster
                 .map(|&id| functions[id as usize].sig_lines)
                 .sum();
             let test_only = ids.iter().all(|&id| functions[id as usize].is_test);
+            let trait_impl_only = ids
+                .iter()
+                .all(|&id| functions[id as usize].is_trait_impl_method);
             Cluster {
                 members,
                 deletable_lines,
                 test_only,
+                trait_impl_only,
             }
         })
         .collect();
@@ -171,6 +179,7 @@ mod tests {
             sig_lines: sig,
             fingerprints: fps,
             is_test: false,
+            is_trait_impl_method: false,
         }
     }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -30,6 +30,10 @@ pub struct FunctionUnit {
     /// Sorted, distinct winnowing fingerprints of the body.
     pub fingerprints: Vec<u64>,
     pub is_test: bool,
+    /// Rust only: a method inside an `impl Trait for Type` block. Every impl
+    /// of the same trait shares the method name (`from`, `fmt`, ...) by
+    /// definition, so these are near-duplicates that cannot be merged.
+    pub is_trait_impl_method: bool,
 }
 
 pub struct FileAnalysis {
@@ -63,6 +67,25 @@ fn cfg_test_mod_offset(src: &str) -> Option<u32> {
         from = at + "#[cfg(test)]".len();
     }
     None
+}
+
+/// True if `func` is a method inside a trait implementation
+/// (`impl SomeTrait for SomeType { ... }`). Such methods share their name with
+/// every other impl of the same trait (`from`, `fmt`, `cmp`, ...) by
+/// definition, so dupehound clusters them as look-alikes even though each is a
+/// distinct, required implementation that cannot be merged away. Inherent
+/// impls (`impl Type { ... }`) have no `trait` field and are not flagged.
+fn is_rust_trait_impl_method(func: Node) -> bool {
+    let Some(decl_list) = func.parent() else {
+        return false;
+    };
+    if decl_list.kind() != "declaration_list" {
+        return false;
+    }
+    let Some(impl_item) = decl_list.parent() else {
+        return false;
+    };
+    impl_item.kind() == "impl_item" && impl_item.child_by_field_name("trait").is_some()
 }
 
 /// Extract and fingerprint every function in `src`. `file` is the caller's
@@ -128,6 +151,7 @@ pub fn analyze_source(
             .unwrap_or("<anonymous>")
             .to_string();
         let is_test = file_is_test || test_boundary.is_some_and(|b| func.start_byte() as u32 >= b);
+        let is_trait_impl_method = lang == Lang::Rust && is_rust_trait_impl_method(func);
         functions.push(FunctionUnit {
             file,
             lang,
@@ -139,6 +163,7 @@ pub fn analyze_source(
             sig_lines: normalized.sig_lines,
             fingerprints,
             is_test,
+            is_trait_impl_method,
         });
     }
 
@@ -287,6 +312,7 @@ pub fn extract_class_shapes(
             sig_lines: member_count,
             fingerprints,
             is_test: file_is_test,
+            is_trait_impl_method: false,
         });
     }
     units
@@ -441,5 +467,18 @@ public class Tiny {
         assert_eq!(fa.functions.len(), 2);
         assert!(!fa.functions[0].is_test);
         assert!(fa.functions[1].is_test);
+    }
+
+    #[test]
+    fn rust_trait_impl_methods_are_flagged() {
+        // A trait impl (`fmt`) and an inherent impl (`area`). Only the trait
+        // method is flagged; the inherent method is normal, scorable code.
+        let src = "struct S { w: u32, h: u32 }\n\nimpl std::fmt::Display for S {\n    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {\n        let a = self.w + self.h;\n        let b = a * 2;\n        write!(f, \"{} {}\", a, b)\n    }\n}\n\nimpl S {\n    fn area(&self) -> u32 {\n        let a = self.w * self.h;\n        let b = a + 1;\n        a + b\n    }\n}\n";
+        let fa = analyze_source(0, Lang::Rust, src, 5, false).unwrap();
+        assert_eq!(fa.functions.len(), 2);
+        let fmt = fa.functions.iter().find(|f| f.name == "fmt").unwrap();
+        let area = fa.functions.iter().find(|f| f.name == "area").unwrap();
+        assert!(fmt.is_trait_impl_method);
+        assert!(!area.is_trait_impl_method);
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -50,7 +50,15 @@ pub struct ClusterOut {
     pub similarity: f64,
     pub deletable_lines: u32,
     pub test_only: bool,
+    /// Rust trait-impl look-alikes (`From`/`Display`/...), kept out of the
+    /// slop score. Omitted when false so existing output is unchanged.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub trait_impl_only: bool,
     pub members: Vec<MemberOut>,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 #[derive(Serialize)]
@@ -108,6 +116,7 @@ pub fn clusters_out(
                 similarity,
                 deletable_lines: c.deletable_lines,
                 test_only: c.test_only,
+                trait_impl_only: c.trait_impl_only,
                 members,
             }
         })

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -192,6 +192,8 @@ fn clusters(out: &mut String, r: &Report, all: bool) {
 fn render_cluster(out: &mut String, c: &ClusterOut) {
     let test_tag = if c.test_only {
         " · [tests, not scored]"
+    } else if c.trait_impl_only {
+        " · [trait impls, not scored]"
     } else {
         ""
     };

--- a/src/score.rs
+++ b/src/score.rs
@@ -17,6 +17,7 @@ pub struct Score {
 pub fn slop_score(clusters: &[Cluster], total_sig_lines: u64, tests: TestPolicy) -> Score {
     let deletable: u64 = clusters
         .iter()
+        .filter(|c| !c.trait_impl_only)
         .filter(|c| tests == TestPolicy::Include || !c.test_only)
         .map(|c| c.deletable_lines as u64)
         .sum();
@@ -53,7 +54,24 @@ mod tests {
             members: vec![],
             deletable_lines: deletable,
             test_only,
+            trait_impl_only: false,
         }
+    }
+
+    #[test]
+    fn score_excludes_trait_impl_clusters_always() {
+        let trait_cluster = Cluster {
+            members: vec![],
+            deletable_lines: 200,
+            test_only: false,
+            trait_impl_only: true,
+        };
+        let clusters = vec![cluster(50, false), trait_cluster];
+        // Trait-impl clusters never count, even with --include-tests.
+        let s = slop_score(&clusters, 1000, TestPolicy::FlagOnly);
+        assert!((s.percent - 5.0).abs() < 1e-9);
+        let s = slop_score(&clusters, 1000, TestPolicy::Include);
+        assert!((s.percent - 5.0).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
Every `impl From<X> for Y` has a `fn from`, every `Display`/`Debug` impl has a `fn fmt`. dupehound clustered these as duplicates and counted them as deletable, inflating the slop score on Rust repos and burying real findings (#28).

Each impl is distinct and required, so it cannot be merged. A method inside an `impl Trait for Type` block is now kept out of the slop score, the same way test-only clusters are. Inherent-impl methods are unaffected. Detection is structural (the enclosing `impl_item` has a `trait` field), not name-based.

Not dropped: still shown tagged `[trait impls, not scored]` and in JSON as `trait_impl_only` (omitted when false, so existing output is unchanged).

Closes #28. Verified with fmt, clippy -D warnings, the full suite plus new tests, and an end-to-end scan confirming a 3-copy `From` cluster is excluded while a real duplicate pair still counts.