### PR TITLE
feat(mcp): expose check and scan over MCP for the agent loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ src/api/orders.ts:1 calculateOrderAmount() is a 100% duplicate of src/billing/in
 
 A GitHub Actions recipe and a pre-commit setup are in [docs/ci.md](docs/ci.md). <br><br>To make a coding agent reuse code instead of rewriting it, feed `check` back to it from `CLAUDE.md` or `AGENTS.md`; the snippet is there too.
 
+### `mcp`
+
+`dupehound mcp` runs as an MCP server over stdio, exposing `check` and `scan` as tools an AI coding agent can call itself, mid-edit, to reuse existing code instead of rebuilding it. It stays local and offline (stdio is a local pipe), deterministic, and no AI. Add it to Claude Code with:
+
+```
+claude mcp add dupehound -- dupehound mcp
+```
+
+The agent then has a `check_duplication` tool (did this change duplicate existing code, and where is the original) and a `scan_duplication` tool (the repo's duplication score and clusters).
+
 ## How it works
 
 Function bodies are parsed with tree-sitter and normalized: identifiers, strings and numbers become sentinels, comments are dropped, structure stays. k-grams of 10 tokens are rolling-hashed and selected by robust winnowing ([Schleimer, Wilkerson & Aiken, SIGMOD 2003](https://theory.stanford.edu/~aiken/publications/papers/sigmod03.pdf)), which guarantees any shared run of 17 normalized tokens is caught.<br><br> An inverted fingerprint index generates candidate pairs, boilerplate fingerprints are culled, similarity is exact Jaccard, union-find builds the clusters.

--- a/src/check.rs
+++ b/src/check.rs
@@ -30,17 +30,25 @@ enum Mode {
 }
 
 #[derive(Serialize)]
-struct Finding {
-    file: String,
-    line: u32,
-    name: String,
-    similarity: f64,
-    original_file: String,
-    original_line: u32,
-    original_name: String,
+pub struct Finding {
+    pub file: String,
+    pub line: u32,
+    pub name: String,
+    pub similarity: f64,
+    pub original_file: String,
+    pub original_line: u32,
+    pub original_name: String,
 }
 
-pub fn run(args: CheckArgs) -> Result<i32> {
+/// The result of a check: whether the changeset touched any code at all, and
+/// the duplicate findings. The CLI and the MCP server share this; only the CLI
+/// turns it into printed output.
+pub struct CheckOutcome {
+    pub had_changes: bool,
+    pub findings: Vec<Finding>,
+}
+
+pub fn compute(args: &CheckArgs) -> Result<CheckOutcome> {
     let config = Config::from_common(&args.common, DEFAULT_CHECK_THRESHOLD);
     let repo = repo_root(&args.path)?;
 
@@ -88,8 +96,10 @@ pub fn run(args: CheckArgs) -> Result<i32> {
         }
     }
     if changed.is_empty() {
-        println!("dupehound check: no changes to check");
-        return Ok(0);
+        return Ok(CheckOutcome {
+            had_changes: false,
+            findings: Vec::new(),
+        });
     }
 
     // Index every function as of the base revision.
@@ -176,18 +186,32 @@ pub fn run(args: CheckArgs) -> Result<i32> {
     }
 
     findings.sort_by(|a, b| (a.file.as_str(), a.line).cmp(&(b.file.as_str(), b.line)));
-    if config.json {
+    Ok(CheckOutcome {
+        had_changes: true,
+        findings,
+    })
+}
+
+/// CLI entry: compute findings, then print them. Exit codes: 0 clean or no
+/// changes, 1 duplicates found, 2 error (the `?` bubbles to main).
+pub fn run(args: CheckArgs) -> Result<i32> {
+    let outcome = compute(&args)?;
+    if !outcome.had_changes {
+        println!("dupehound check: no changes to check");
+        return Ok(0);
+    }
+    if args.common.json {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
                 "schema_version": crate::report::JSON_SCHEMA_VERSION,
-                "findings": findings,
+                "findings": outcome.findings,
             }))?
         );
-    } else if findings.is_empty() {
+    } else if outcome.findings.is_empty() {
         println!("dupehound check: no new duplicates ✓");
     } else {
-        for f in &findings {
+        for f in &outcome.findings {
             println!(
                 "{}:{} {}() is a {:.0}% duplicate of {}:{} {}() — reuse it",
                 f.file,
@@ -201,11 +225,11 @@ pub fn run(args: CheckArgs) -> Result<i32> {
         }
         eprintln!(
             "\ndupehound check: {} new duplicate{} of existing code",
-            findings.len(),
-            if findings.len() == 1 { "" } else { "s" }
+            outcome.findings.len(),
+            if outcome.findings.len() == 1 { "" } else { "s" }
         );
     }
-    Ok(if findings.is_empty() { 0 } else { 1 })
+    Ok(if outcome.findings.is_empty() { 0 } else { 1 })
 }
 
 /// New-side content of a changed file, depending on mode.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,9 @@ pub enum Command {
     History(HistoryArgs),
     /// CI gate: fail when newly added code duplicates existing code
     Check(CheckArgs),
+    /// Run as an MCP server over stdio, exposing check and scan as tools an
+    /// AI coding agent can call in its loop
+    Mcp,
 }
 
 #[derive(Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod gitsnap;
 mod history;
 mod index;
 mod lang;
+mod mcp;
 mod normalize;
 mod report;
 mod scan;
@@ -34,5 +35,6 @@ fn run(cli: cli::Cli) -> anyhow::Result<i32> {
         cli::Command::Scan(args) => scan::run(args),
         cli::Command::History(args) => history::run(args),
         cli::Command::Check(args) => check::run(args),
+        cli::Command::Mcp => mcp::run(),
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,280 @@
+//! `dupehound mcp`: expose `check` and `scan` as Model Context Protocol tools
+//! over stdio, so an AI coding agent can call them itself inside its loop and
+//! reuse existing code instead of rebuilding it.
+//!
+//! This is a hand-rolled, minimal JSON-RPC 2.0 server over newline-delimited
+//! stdio. No async runtime, no network: the only thing written to stdout is a
+//! protocol message, and the analysis stays the same local, deterministic, no-AI
+//! engine the CLI uses. Keeping it dependency-free (just serde_json, already a
+//! dependency) is why it ships in the default binary with no feature flag.
+
+use crate::check;
+use crate::cli::{CheckArgs, CommonArgs};
+use crate::config::{Config, DEFAULT_SCAN_THRESHOLD};
+use crate::scan;
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+
+const SERVER_NAME: &str = "dupehound";
+/// Echoed back to the client when it does not request a specific version.
+const DEFAULT_PROTOCOL: &str = "2025-06-18";
+
+/// Read JSON-RPC messages from stdin line by line, dispatch, write responses to
+/// stdout. Notifications (no `id`) never get a reply. Runs until stdin closes.
+pub fn run() -> Result<i32> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let msg: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => {
+                write_msg(&mut out, &error(&Value::Null, -32700, "parse error"))?;
+                continue;
+            }
+        };
+        // Requests carry an `id`; notifications do not and get no response.
+        let Some(id) = msg.get("id").cloned() else {
+            continue;
+        };
+        let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
+        let response = handle(method, msg.get("params"), &id);
+        write_msg(&mut out, &response)?;
+    }
+    Ok(0)
+}
+
+fn write_msg(out: &mut impl Write, msg: &Value) -> Result<()> {
+    writeln!(out, "{}", serde_json::to_string(msg)?)?;
+    out.flush()?;
+    Ok(())
+}
+
+fn success(id: &Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn error(id: &Value, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+fn handle(method: &str, params: Option<&Value>, id: &Value) -> Value {
+    match method {
+        "initialize" => {
+            let protocol = params
+                .and_then(|p| p.get("protocolVersion"))
+                .and_then(Value::as_str)
+                .unwrap_or(DEFAULT_PROTOCOL)
+                .to_string();
+            success(
+                id,
+                json!({
+                    "protocolVersion": protocol,
+                    "capabilities": { "tools": {} },
+                    "serverInfo": { "name": SERVER_NAME, "version": env!("CARGO_PKG_VERSION") },
+                }),
+            )
+        }
+        "ping" => success(id, json!({})),
+        "tools/list" => success(id, json!({ "tools": tool_defs() })),
+        // A failing tool is a successful response whose result is flagged
+        // isError, not a JSON-RPC protocol error.
+        "tools/call" => match call_tool(params) {
+            Ok(result) => success(id, result),
+            Err(e) => success(id, tool_error(&e.to_string())),
+        },
+        _ => error(id, -32601, "method not found"),
+    }
+}
+
+fn tool_defs() -> Value {
+    json!([
+        {
+            "name": "check_duplication",
+            "description": "Check whether code changed in a git repo duplicates code that already exists elsewhere in the repo, and point to the original function to reuse. Deterministic, local, no AI. Run it after editing so the agent reuses existing code instead of rebuilding it. Matches on structure, so it catches duplicates even when they were renamed.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "Path to the git repository. Defaults to the current directory." },
+                    "diff": { "type": "string", "description": "Optional git revision to compare against (merge-base, PR semantics). Without it, checks staged changes, otherwise the working tree." },
+                    "threshold": { "type": "number", "description": "Similarity threshold from 0 to 1. Defaults to 0.85." }
+                }
+            }
+        },
+        {
+            "name": "scan_duplication",
+            "description": "Scan a whole directory for duplicate functions and return the duplication (slop) score, grade, and the duplicate clusters. Deterministic, local, no AI.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "Directory to scan. Defaults to the current directory." },
+                    "threshold": { "type": "number", "description": "Similarity threshold from 0 to 1. Defaults to 0.80." }
+                }
+            }
+        }
+    ])
+}
+
+fn call_tool(params: Option<&Value>) -> Result<Value> {
+    let params = params.ok_or_else(|| anyhow!("missing params"))?;
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("missing tool name"))?;
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    match name {
+        "check_duplication" => run_check(&args),
+        "scan_duplication" => run_scan(&args),
+        other => Err(anyhow!("unknown tool: {other}")),
+    }
+}
+
+/// A clap `CommonArgs` with CLI defaults, optionally overriding the threshold.
+fn common_args(threshold: Option<f64>) -> CommonArgs {
+    CommonArgs {
+        threshold,
+        min_tokens: 40,
+        excludes: Vec::new(),
+        no_default_excludes: false,
+        include_tests: false,
+        exclude_tests: false,
+        json: false,
+    }
+}
+
+fn run_check(args: &Value) -> Result<Value> {
+    let path = args.get("path").and_then(Value::as_str).unwrap_or(".");
+    let diff = args.get("diff").and_then(Value::as_str).map(str::to_string);
+    let threshold = args.get("threshold").and_then(Value::as_f64);
+
+    let check_args = CheckArgs {
+        path: PathBuf::from(path),
+        common: common_args(threshold),
+        diff,
+    };
+    let outcome = check::compute(&check_args)?;
+
+    let summary = if !outcome.had_changes {
+        "No changes to check.".to_string()
+    } else if outcome.findings.is_empty() {
+        "No new duplicates of existing code.".to_string()
+    } else {
+        format!(
+            "{} new duplicate(s) of existing code. Reuse the original each finding points to instead of rewriting it.",
+            outcome.findings.len()
+        )
+    };
+    let structured = json!({
+        "had_changes": outcome.had_changes,
+        "findings": serde_json::to_value(&outcome.findings)?,
+    });
+    Ok(tool_result(&summary, structured))
+}
+
+fn run_scan(args: &Value) -> Result<Value> {
+    let path = args.get("path").and_then(Value::as_str).unwrap_or(".");
+    let threshold = args.get("threshold").and_then(Value::as_f64);
+
+    let config = Config::from_common(&common_args(threshold), DEFAULT_SCAN_THRESHOLD);
+    let output = scan::scan_path(&PathBuf::from(path), &config)?;
+    let report = &output.report;
+    let summary = format!(
+        "Slop score {:.1}% (grade {}). {} duplicate cluster(s) across {} functions in {} files.",
+        report.score.slop_percent,
+        report.score.grade,
+        report.clusters.len(),
+        report.stats.functions,
+        report.stats.files,
+    );
+    Ok(tool_result(&summary, serde_json::to_value(report)?))
+}
+
+/// Build an MCP tool result: a human/agent-readable text block (summary plus the
+/// JSON, so any client can read it) and the structured object for clients that
+/// consume `structuredContent`.
+fn tool_result(summary: &str, structured: Value) -> Value {
+    let pretty = serde_json::to_string_pretty(&structured).unwrap_or_default();
+    json!({
+        "content": [ { "type": "text", "text": format!("{summary}\n\n{pretty}") } ],
+        "structuredContent": structured,
+        "isError": false,
+    })
+}
+
+fn tool_error(message: &str) -> Value {
+    json!({
+        "content": [ { "type": "text", "text": message } ],
+        "isError": true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_echoes_protocol_and_names_the_server() {
+        let params = json!({ "protocolVersion": "2025-03-26" });
+        let r = handle("initialize", Some(&params), &json!(1));
+        assert_eq!(r["result"]["protocolVersion"], "2025-03-26");
+        assert_eq!(r["result"]["serverInfo"]["name"], "dupehound");
+        assert!(r["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[test]
+    fn initialize_falls_back_to_default_protocol() {
+        let r = handle("initialize", Some(&json!({})), &json!(1));
+        assert_eq!(r["result"]["protocolVersion"], DEFAULT_PROTOCOL);
+    }
+
+    #[test]
+    fn tools_list_exposes_both_tools_with_object_schemas() {
+        let r = handle("tools/list", None, &json!(2));
+        let tools = r["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"check_duplication"));
+        assert!(names.contains(&"scan_duplication"));
+        for t in tools {
+            assert_eq!(t["inputSchema"]["type"], "object");
+        }
+    }
+
+    #[test]
+    fn unknown_method_is_a_protocol_error() {
+        let r = handle("does/not/exist", None, &json!(3));
+        assert_eq!(r["error"]["code"], -32601);
+    }
+
+    #[test]
+    fn ping_returns_empty_result() {
+        let r = handle("ping", None, &json!(4));
+        assert!(r["result"].is_object());
+        assert!(r.get("error").is_none());
+    }
+
+    #[test]
+    fn unknown_tool_is_an_is_error_result_not_a_protocol_error() {
+        let params = json!({ "name": "nope", "arguments": {} });
+        let r = handle("tools/call", Some(&params), &json!(5));
+        // Protocol-level success, tool-level error.
+        assert!(r.get("error").is_none());
+        assert_eq!(r["result"]["isError"], true);
+    }
+
+    #[test]
+    fn missing_tool_name_is_an_is_error_result() {
+        let params = json!({ "arguments": {} });
+        let r = handle("tools/call", Some(&params), &json!(6));
+        assert_eq!(r["result"]["isError"], true);
+    }
+}


### PR DESCRIPTION
Adds `dupehound mcp`, an MCP server over stdio that lets a coding agent call `check` and `scan` itself while it edits, so it reuses existing code instead of rebuilding it. That is the best place for it: the agents writing code are the ones creating the duplicates.

It is a small hand-rolled JSON-RPC server, no async runtime and no new heavy dependency, so it ships in the default binary. Stays local, offline, deterministic, no AI. Only protocol messages go to stdout.

Two tools: `check_duplication` (did this change duplicate existing code, and where is the original) and `scan_duplication` (the repo's score and clusters). Setup is `claude mcp add dupehound -- dupehound mcp`.

Splits `check` into a pure `compute` and a `run` that prints, so the CLI and the MCP share one engine. CLI output is unchanged.

Closes #26. Verified with fmt, clippy, the full suite plus 7 protocol tests, and a real stdio session.