### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.2 (2026-06-22)
+
+- `dupehound mcp`: run as an MCP server over stdio, exposing `check` and `scan` as tools an AI coding agent can call in its loop to reuse existing code instead of rebuilding it. Local, offline, deterministic, no AI (#30).
+- C# support via tree-sitter-c-sharp (#20).
+- `scan --include-classes`: experimental, opt-in detection of C# classes whose property and method signatures are near-duplicates. Separate from the function clusters and never affects the slop score (#25).
+- `scan`: Rust trait-impl methods (`From`, `Display`, ...) are kept out of the slop score, since each impl is required and cannot be merged (#29).
+
 ## 0.1.0 (2026-06-12)
 
 Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dupehound"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dupehound"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Sniffs out near-duplicate code in any codebase. Fast, offline, no AI required."
 license = "MIT"


### PR DESCRIPTION
Bumps to 0.1.2. Highlights since 0.1.1: the `dupehound mcp` server (#30), C# support (#20), the experimental `--include-classes` C# class-shape track (#25), and Rust trait-impl segmentation in the slop score (#29). Full notes in CHANGELOG.md.