### PR TITLE
feat(lang): add Kotlin support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-kotlin-ng",
  "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-ruby",
@@ -1161,6 +1162,16 @@ name = "tree-sitter-javascript"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-ng"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tree-sitter-swift = "0.7.3"
 tree-sitter-php = "0.22.2"
 unicode-width = "0.2.2"
 tree-sitter-c-sharp = "0.23.5"
+tree-sitter-kotlin-ng = "1.1.0"
 
 [dev-dependencies]
 insta = { version = "1.47.2", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The slop score is the percentage of code you could delete if every cluster kept 
 <li><code>--include-classes</code> flags C# classes with near-duplicate property and method signatures (experimental, opt-in, never affects the slop score)</li>
 </ul>
 
-Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#.
+Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#, Kotlin.
 
 ### `history`
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -17,10 +17,11 @@ pub enum Lang {
     Cpp,
     Php,
     Csharp,
+    Kotlin,
 }
 
 #[cfg(test)]
-pub const ALL: [Lang; 13] = [
+pub const ALL: [Lang; 14] = [
     Lang::Typescript,
     Lang::Tsx,
     Lang::Javascript,
@@ -34,6 +35,7 @@ pub const ALL: [Lang; 13] = [
     Lang::Cpp,
     Lang::Php,
     Lang::Csharp,
+    Lang::Kotlin,
 ];
 
 impl Lang {
@@ -53,6 +55,7 @@ impl Lang {
             "cc" | "cpp" | "cxx" | "c++" | "hpp" | "hh" | "hxx" => Some(Lang::Cpp),
             "php" => Some(Lang::Php),
             "cs" => Some(Lang::Csharp),
+            "kt" | "kts" => Some(Lang::Kotlin),
             _ => None,
         }
     }
@@ -72,6 +75,7 @@ impl Lang {
             Lang::Cpp => "C++",
             Lang::Php => "Php",
             Lang::Csharp => "C#",
+            Lang::Kotlin => "Kotlin",
         }
     }
 
@@ -90,6 +94,7 @@ impl Lang {
             Lang::C => tree_sitter_c::LANGUAGE.into(),
             Lang::Cpp => tree_sitter_cpp::LANGUAGE.into(),
             Lang::Csharp => tree_sitter_c_sharp::LANGUAGE.into(),
+            Lang::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
         }
     }
 
@@ -107,11 +112,12 @@ impl Lang {
             Lang::Cpp => include_str!("queries/cpp.scm"),
             Lang::Php => include_str!("queries/php.scm"),
             Lang::Csharp => include_str!("queries/csharp.scm"),
+            Lang::Kotlin => include_str!("queries/kotlin.scm"),
         }
     }
 
     pub fn query(self) -> &'static Query {
-        static QUERIES: [OnceLock<Query>; 13] = [const { OnceLock::new() }; 13];
+        static QUERIES: [OnceLock<Query>; 14] = [const { OnceLock::new() }; 14];
         QUERIES[self as usize].get_or_init(|| {
             Query::new(&self.language(), self.query_source())
                 .unwrap_or_else(|e| panic!("bad {} query: {e}", self.name()))
@@ -129,7 +135,7 @@ impl Lang {
 
     pub fn shape_query(self) -> Option<&'static Query> {
         let src = self.shape_query_source()?;
-        static SHAPE_QUERIES: [OnceLock<Query>; 13] = [const { OnceLock::new() }; 13];
+        static SHAPE_QUERIES: [OnceLock<Query>; 14] = [const { OnceLock::new() }; 14];
         Some(SHAPE_QUERIES[self as usize].get_or_init(|| {
             Query::new(&self.language(), src)
                 .unwrap_or_else(|e| panic!("bad {} shape query: {e}", self.name()))

--- a/src/lang/queries/kotlin.scm
+++ b/src/lang/queries/kotlin.scm
@@ -1,0 +1,3 @@
+(function_declaration
+  name: (identifier) @name
+  (function_body (block) @body)) @func

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -108,7 +108,7 @@ pub fn discover(root: &Path, config: &Config) -> Result<Vec<DiscoveredFile>> {
     if files.is_empty() {
         anyhow::bail!(
             "no supported source files found under {} \
-             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb .swift .c .h .cpp .cc .hpp .php .cs)",
+             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb .swift .c .h .cpp .cc .hpp .php .cs .kt .kts)",
             root.display()
         );
     }
@@ -162,6 +162,8 @@ pub fn is_test_path(rel: &str) -> bool {
         || file.ends_with("spec.swift")
         || file.ends_with("test.php")
         || file.ends_with("tests.php")
+        || file.ends_with("test.kt")
+        || file.ends_with("tests.kt")
     {
         return true;
     }

--- a/tests/languages.rs
+++ b/tests/languages.rs
@@ -97,6 +97,40 @@ class Invoices
 "#,
 };
 
+const KOTLIN: Fixture = Fixture {
+    file_a: "Billing.kt",
+    file_b: "Invoices.kt",
+    names: ("computeTotal", "calculateAmount"),
+    src_a: r#"
+fun computeTotal(items: List<Map<String, Double>>, taxRate: Double): Double {
+    var subtotal = 0.0
+    for (item in items) {
+        var price = item["price"]!! * item["qty"]!!
+        if (item.containsKey("discount")) {
+            price = price * (1.0 - item["discount"]!!)
+        }
+        subtotal += price
+    }
+    val tax = subtotal * taxRate
+    return subtotal + tax
+}
+"#,
+    src_b: r#"
+fun calculateAmount(rows: List<Map<String, Double>>, vat: Double): Double {
+    var baseAmount = 0.0
+    for (row in rows) {
+        var cost = row["price"]!! * row["qty"]!!
+        if (row.containsKey("discount")) {
+            cost = cost * (1.0 - row["discount"]!!)
+        }
+        baseAmount += cost
+    }
+    val extra = baseAmount * vat
+    return baseAmount + extra
+}
+"#,
+};
+
 const PYTHON: Fixture = Fixture {
     file_a: "billing.py",
     file_b: "invoices.py",
@@ -600,6 +634,10 @@ fn php_renamed_clone_is_detected() {
 #[test]
 fn csharp_renamed_clone_is_detected() {
     assert_clone_pair_detected(&CSHARP);
+}
+#[test]
+fn kotlin_renamed_clone_is_detected() {
+    assert_clone_pair_detected(&KOTLIN);
 }
 #[test]
 fn c_pointer_return_clone_is_detected() {


### PR DESCRIPTION
Adds Kotlin (#5): `.kt` and `.kts` files now get scanned for duplicate functions like the rest.

Uses tree-sitter-kotlin-ng (ABI 14). A small `kotlin.scm` captures function bodies, and the existing token classifier already handles Kotlin, so no normalizer change. Test files (`*Test.kt`) are flagged like the others.

Verified with a renamed-clone fixture (every identifier changed), fmt, clippy, and the full suite (the ABI and query-compile tests now cover 14 languages).

Closes #5