### PR TITLE
feat(lang): add Scala support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-scala",
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "unicode-width",
@@ -1218,6 +1219,16 @@ name = "tree-sitter-rust"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5a4a7ff23a55474ce6a741d52aaeca7a82fe9421bb982b86e98c6ac8629397"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tree-sitter-php = "0.22.2"
 unicode-width = "0.2.2"
 tree-sitter-c-sharp = "0.23.5"
 tree-sitter-kotlin-ng = "1.1.0"
+tree-sitter-scala = "0.26.0"
 
 [dev-dependencies]
 insta = { version = "1.47.2", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The slop score is the percentage of code you could delete if every cluster kept 
 <li><code>--include-classes</code> flags C# classes with near-duplicate property and method signatures (experimental, opt-in, never affects the slop score)</li>
 </ul>
 
-Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#, Kotlin.
+Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#, Kotlin, Scala.
 
 ### `history`
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -18,10 +18,11 @@ pub enum Lang {
     Php,
     Csharp,
     Kotlin,
+    Scala,
 }
 
 #[cfg(test)]
-pub const ALL: [Lang; 14] = [
+pub const ALL: [Lang; 15] = [
     Lang::Typescript,
     Lang::Tsx,
     Lang::Javascript,
@@ -36,6 +37,7 @@ pub const ALL: [Lang; 14] = [
     Lang::Php,
     Lang::Csharp,
     Lang::Kotlin,
+    Lang::Scala,
 ];
 
 impl Lang {
@@ -56,6 +58,7 @@ impl Lang {
             "php" => Some(Lang::Php),
             "cs" => Some(Lang::Csharp),
             "kt" | "kts" => Some(Lang::Kotlin),
+            "scala" | "sc" => Some(Lang::Scala),
             _ => None,
         }
     }
@@ -76,6 +79,7 @@ impl Lang {
             Lang::Php => "Php",
             Lang::Csharp => "C#",
             Lang::Kotlin => "Kotlin",
+            Lang::Scala => "Scala",
         }
     }
 
@@ -95,6 +99,7 @@ impl Lang {
             Lang::Cpp => tree_sitter_cpp::LANGUAGE.into(),
             Lang::Csharp => tree_sitter_c_sharp::LANGUAGE.into(),
             Lang::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
+            Lang::Scala => tree_sitter_scala::LANGUAGE.into(),
         }
     }
 
@@ -113,11 +118,12 @@ impl Lang {
             Lang::Php => include_str!("queries/php.scm"),
             Lang::Csharp => include_str!("queries/csharp.scm"),
             Lang::Kotlin => include_str!("queries/kotlin.scm"),
+            Lang::Scala => include_str!("queries/scala.scm"),
         }
     }
 
     pub fn query(self) -> &'static Query {
-        static QUERIES: [OnceLock<Query>; 14] = [const { OnceLock::new() }; 14];
+        static QUERIES: [OnceLock<Query>; 15] = [const { OnceLock::new() }; 15];
         QUERIES[self as usize].get_or_init(|| {
             Query::new(&self.language(), self.query_source())
                 .unwrap_or_else(|e| panic!("bad {} query: {e}", self.name()))
@@ -135,7 +141,7 @@ impl Lang {
 
     pub fn shape_query(self) -> Option<&'static Query> {
         let src = self.shape_query_source()?;
-        static SHAPE_QUERIES: [OnceLock<Query>; 14] = [const { OnceLock::new() }; 14];
+        static SHAPE_QUERIES: [OnceLock<Query>; 15] = [const { OnceLock::new() }; 15];
         Some(SHAPE_QUERIES[self as usize].get_or_init(|| {
             Query::new(&self.language(), src)
                 .unwrap_or_else(|e| panic!("bad {} shape query: {e}", self.name()))

--- a/src/lang/queries/scala.scm
+++ b/src/lang/queries/scala.scm
@@ -1,0 +1,3 @@
+(function_definition
+  name: (identifier) @name
+  body: (_) @body) @func

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -108,7 +108,7 @@ pub fn discover(root: &Path, config: &Config) -> Result<Vec<DiscoveredFile>> {
     if files.is_empty() {
         anyhow::bail!(
             "no supported source files found under {} \
-             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb .swift .c .h .cpp .cc .hpp .php .cs .kt .kts)",
+             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb .swift .c .h .cpp .cc .hpp .php .cs .kt .kts .scala .sc)",
             root.display()
         );
     }

--- a/tests/languages.rs
+++ b/tests/languages.rs
@@ -97,6 +97,40 @@ class Invoices
 "#,
 };
 
+const SCALA: Fixture = Fixture {
+    file_a: "Billing.scala",
+    file_b: "Invoices.scala",
+    names: ("computeTotal", "calculateAmount"),
+    src_a: r#"
+def computeTotal(items: List[Map[String, Double]], taxRate: Double): Double = {
+    var subtotal = 0.0
+    for (item <- items) {
+        var price = item("price") * item("qty")
+        if (item.contains("discount")) {
+            price = price * (1.0 - item("discount"))
+        }
+        subtotal += price
+    }
+    val tax = subtotal * taxRate
+    subtotal + tax
+}
+"#,
+    src_b: r#"
+def calculateAmount(rows: List[Map[String, Double]], vat: Double): Double = {
+    var baseAmount = 0.0
+    for (row <- rows) {
+        var cost = row("price") * row("qty")
+        if (row.contains("discount")) {
+            cost = cost * (1.0 - row("discount"))
+        }
+        baseAmount += cost
+    }
+    val extra = baseAmount * vat
+    baseAmount + extra
+}
+"#,
+};
+
 const KOTLIN: Fixture = Fixture {
     file_a: "Billing.kt",
     file_b: "Invoices.kt",
@@ -638,6 +672,10 @@ fn csharp_renamed_clone_is_detected() {
 #[test]
 fn kotlin_renamed_clone_is_detected() {
     assert_clone_pair_detected(&KOTLIN);
+}
+#[test]
+fn scala_renamed_clone_is_detected() {
+    assert_clone_pair_detected(&SCALA);
 }
 #[test]
 fn c_pointer_return_clone_is_detected() {


### PR DESCRIPTION
Adds Scala as the 15th language. A grammar-driven addition: the `tree-sitter-scala` crate plus a query that captures `function_definition` (free functions and methods, both brace-block and `= expression` bodies). A renamed-clone fixture proves a Type-2 copy fingerprints identically.

cargo test, cargo clippy --all-targets, and cargo fmt --check are all green.