### PR TITLE
feat(scan): flag a small function copied into a larger one (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `check`: alongside each duplicate, print the import that brings the original into scope so you can delete the copy. Derived from the file path for Rust, Python, TypeScript, TSX and JavaScript; other languages print no import. Suggestion only, in text and JSON; dupehound never edits files (#9).
+- `scan --containment`: experimental, opt-in detection of a small function copied into a larger one. Jaccard misses this because the larger body inflates the union; containment measures the shared fingerprints against the smaller function alone. Separate from the clusters and never affects the slop score (#7).
 
 ## 0.1.2 (2026-06-22)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The slop score is the percentage of code you could delete if every cluster kept 
 <li><code>--json</code> emits a versioned schema</li>
 <li><code>--card</code> writes a score card as SVG and PNG</li>
 <li><code>--include-classes</code> flags C# classes with near-duplicate property and method signatures (experimental, opt-in, never affects the slop score)</li>
+<li><code>--containment</code> flags a small function copied into a larger one, which the Jaccard score misses because the larger body inflates the union (experimental, opt-in, never affects the slop score)</li>
 </ul>
 
 Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#, Kotlin, Scala.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,11 @@ pub struct ScanArgs {
     /// are near-duplicates (separate from the function clusters and the score)
     #[arg(long)]
     pub include_classes: bool,
+
+    /// Experimental: also report small functions copied into a larger one,
+    /// which the Jaccard score misses (separate from the clusters and the score)
+    #[arg(long)]
+    pub containment: bool,
 }
 
 #[derive(Args)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,12 @@ pub const DEFAULT_CHECK_THRESHOLD: f64 = 0.85;
 /// Minimum raw shared fingerprints before we bother computing exact Jaccard.
 pub const MIN_SHARED_PREFILTER: u32 = 3;
 
+/// How much of the smaller function must be covered by the larger one for the
+/// experimental `--containment` track to report it. Stricter than the Jaccard
+/// threshold on purpose: containment ignores the larger body, so a loose bar
+/// here would flag any small function that happens to share a few fingerprints.
+pub const DEFAULT_CONTAINMENT_THRESHOLD: f64 = 0.90;
+
 /// Files larger than this are skipped (almost certainly generated/minified).
 pub const MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
 
@@ -35,6 +41,9 @@ pub struct Config {
     pub json: bool,
     /// Experimental: also run the C# "class shape" track (scan only).
     pub include_classes: bool,
+    /// Experimental: also report small functions copied into larger ones
+    /// (scan only), which Jaccard alone misses.
+    pub containment: bool,
 }
 
 impl Config {
@@ -57,6 +66,7 @@ impl Config {
             tests,
             json: common.json,
             include_classes: false,
+            containment: false,
         }
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -119,3 +119,186 @@ fn pairs_within(
 pub fn similarity(a: &FunctionUnit, b: &FunctionUnit) -> f64 {
     jaccard(&a.fingerprints, &b.fingerprints)
 }
+
+/// A small function whose fingerprints are almost entirely contained in a
+/// larger one — the "copied into a bigger function" case Jaccard misses,
+/// because the larger body inflates the union while the intersection stays
+/// bounded by the small one.
+pub struct ContainmentPair {
+    pub small: u32,
+    pub large: u32,
+    /// shared / |small fingerprints|: how much of the small function the
+    /// larger one covers (0.0-1.0).
+    pub containment: f64,
+}
+
+/// Find containment pairs the normal (Jaccard) scan misses: the smaller
+/// function is at least `containment_threshold` covered by the larger one, yet
+/// their Jaccard stays below `jaccard_threshold`. Runs on the post-cull
+/// fingerprints, so it must be called *after* `find_pairs`. Pairs where one
+/// function is lexically nested inside the other (a closure inside its parent)
+/// are dropped: that overlap is structural, not a copy.
+pub fn find_containment(
+    functions: &[FunctionUnit],
+    jaccard_threshold: f64,
+    containment_threshold: f64,
+    min_shared: u32,
+) -> Vec<ContainmentPair> {
+    let mut by_lang: FxHashMap<crate::lang::Lang, Vec<u32>> = FxHashMap::default();
+    for (i, f) in functions.iter().enumerate() {
+        by_lang.entry(f.lang).or_default().push(i as u32);
+    }
+    let mut out = Vec::new();
+    for ids in by_lang.values() {
+        out.extend(containment_within(
+            functions,
+            ids,
+            jaccard_threshold,
+            containment_threshold,
+            min_shared,
+        ));
+    }
+    out
+}
+
+fn containment_within(
+    functions: &[FunctionUnit],
+    ids: &[u32],
+    jaccard_threshold: f64,
+    containment_threshold: f64,
+    min_shared: u32,
+) -> Vec<ContainmentPair> {
+    let mut postings: FxHashMap<u64, Vec<u32>> = FxHashMap::default();
+    for (pos, &id) in ids.iter().enumerate() {
+        for &fp in &functions[id as usize].fingerprints {
+            postings.entry(fp).or_default().push(pos as u32);
+        }
+    }
+
+    ids.par_iter()
+        .enumerate()
+        .flat_map_iter(|(pos, &id)| {
+            let me = &functions[id as usize];
+            let mut shared: FxHashMap<u32, u32> = FxHashMap::default();
+            for fp in &me.fingerprints {
+                if let Some(list) = postings.get(fp) {
+                    let start = list.partition_point(|&p| p <= pos as u32);
+                    for &other in &list[start..] {
+                        *shared.entry(other).or_insert(0) += 1;
+                    }
+                }
+            }
+            let mut found = Vec::new();
+            for (other_pos, count) in shared {
+                if count < min_shared {
+                    continue;
+                }
+                let other_id = ids[other_pos as usize];
+                let other = &functions[other_id as usize];
+                let (la, lb) = (me.fingerprints.len(), other.fingerprints.len());
+                let union = la + lb - count as usize;
+                let jaccard = if union == 0 {
+                    0.0
+                } else {
+                    count as f64 / union as f64
+                };
+                // Above the Jaccard bar it is already a normal-scan cluster.
+                if jaccard >= jaccard_threshold {
+                    continue;
+                }
+                let min_len = la.min(lb);
+                if min_len == 0 {
+                    continue;
+                }
+                let containment = count as f64 / min_len as f64;
+                if containment < containment_threshold {
+                    continue;
+                }
+                // The smaller fingerprint set is the one being "contained".
+                let (small, large) = if la <= lb {
+                    (id, other_id)
+                } else {
+                    (other_id, id)
+                };
+                if lexically_nested(&functions[small as usize], &functions[large as usize]) {
+                    continue;
+                }
+                found.push(ContainmentPair {
+                    small,
+                    large,
+                    containment,
+                });
+            }
+            found
+        })
+        .collect()
+}
+
+/// True when one function's byte range sits inside the other's within the same
+/// file — a nested fn or closure that matches only because its parent encloses
+/// it, not because it was copied.
+fn lexically_nested(a: &FunctionUnit, b: &FunctionUnit) -> bool {
+    let inside = |inner: &FunctionUnit, outer: &FunctionUnit| {
+        inner.file == outer.file
+            && outer.start_byte <= inner.start_byte
+            && inner.end_byte <= outer.end_byte
+    };
+    inside(a, b) || inside(b, a)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::Lang;
+
+    fn unit(file: u32, bytes: (u32, u32), fps: Vec<u64>) -> FunctionUnit {
+        FunctionUnit {
+            file,
+            lang: Lang::Typescript,
+            name: "f".into(),
+            start_line: 1,
+            end_line: 10,
+            start_byte: bytes.0,
+            end_byte: bytes.1,
+            sig_lines: 10,
+            fingerprints: fps,
+            is_test: false,
+            is_trait_impl_method: false,
+        }
+    }
+
+    #[test]
+    fn small_copied_into_large_is_reported() {
+        // 10-fp function fully contained in a 30-fp one, in different files.
+        // Jaccard = 10/30 = 0.33 (below 0.80), containment = 10/10 = 1.0.
+        let small = (1..=10).collect::<Vec<u64>>();
+        let large = (1..=30).collect::<Vec<u64>>();
+        let functions = vec![unit(0, (0, 100), small), unit(1, (0, 900), large)];
+        let pairs = find_containment(&functions, 0.80, 0.90, 3);
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].small, 0);
+        assert_eq!(pairs[0].large, 1);
+        assert!((pairs[0].containment - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn lexically_nested_pair_is_skipped() {
+        // Same file, small's byte range inside large's: a nested closure, not
+        // a copy. Must not be reported even though containment is 1.0.
+        let small = (1..=10).collect::<Vec<u64>>();
+        let large = (1..=30).collect::<Vec<u64>>();
+        let functions = vec![unit(0, (100, 400), small), unit(0, (0, 900), large)];
+        let pairs = find_containment(&functions, 0.80, 0.90, 3);
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn near_identical_pair_stays_with_jaccard_scan() {
+        // Two same-size functions the normal scan already clusters (Jaccard
+        // 1.0) are not re-reported as containment findings.
+        let fps = (1..=10).collect::<Vec<u64>>();
+        let functions = vec![unit(0, (0, 100), fps.clone()), unit(1, (0, 100), fps)];
+        let pairs = find_containment(&functions, 0.80, 0.90, 3);
+        assert!(pairs.is_empty());
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -20,6 +20,10 @@ pub struct Report {
     /// JSON when empty so the default output is byte-for-byte unchanged.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub class_shapes: Vec<ClusterOut>,
+    /// Experimental containment findings (`--containment`): a small function
+    /// copied into a larger one. Omitted from JSON when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub containment: Vec<ContainmentOut>,
 }
 
 #[derive(Serialize)]
@@ -72,6 +76,76 @@ pub struct MemberOut {
     pub similarity: f64,
     pub representative: bool,
     pub test: bool,
+}
+
+#[derive(Serialize)]
+pub struct ContainmentOut {
+    /// The smaller function, mostly contained in `container`.
+    pub contained: ContainmentSide,
+    /// The larger function it was copied into.
+    pub container: ContainmentSide,
+    /// Fraction of the contained function the container covers (0.0-1.0).
+    pub containment: f64,
+}
+
+#[derive(Serialize)]
+pub struct ContainmentSide {
+    pub file: String,
+    pub name: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub lines: u32,
+}
+
+/// Map containment pairs to their serializable form. Keeps the strongest
+/// container per contained function so one copied helper is reported once, and
+/// sorts by the contained function's size (most lines you could extract first).
+pub fn containment_out(
+    pairs: &[crate::index::ContainmentPair],
+    functions: &[FunctionUnit],
+    file_names: &[String],
+) -> Vec<ContainmentOut> {
+    // Best (highest containment) container per contained function.
+    let mut best: rustc_hash::FxHashMap<u32, &crate::index::ContainmentPair> =
+        rustc_hash::FxHashMap::default();
+    for p in pairs {
+        best.entry(p.small)
+            .and_modify(|cur| {
+                if p.containment > cur.containment {
+                    *cur = p;
+                }
+            })
+            .or_insert(p);
+    }
+
+    let side = |id: u32| {
+        let f = &functions[id as usize];
+        ContainmentSide {
+            file: file_names[f.file as usize].clone(),
+            name: f.name.clone(),
+            start_line: f.start_line,
+            end_line: f.end_line,
+            lines: f.sig_lines,
+        }
+    };
+
+    let mut out: Vec<ContainmentOut> = best
+        .values()
+        .map(|p| ContainmentOut {
+            contained: side(p.small),
+            container: side(p.large),
+            containment: p.containment,
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        b.contained
+            .lines
+            .cmp(&a.contained.lines)
+            .then(b.containment.total_cmp(&a.containment))
+            .then(a.contained.file.cmp(&b.contained.file))
+            .then(a.contained.start_line.cmp(&b.contained.start_line))
+    });
+    out
 }
 
 /// Map internal clusters to their serializable form. Shared by the function
@@ -147,5 +221,6 @@ pub fn build(
         },
         clusters: clusters_out,
         class_shapes: Vec::new(),
+        containment: Vec::new(),
     }
 }

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -102,6 +102,65 @@ pub fn render_shapes(report: &Report) -> String {
     out
 }
 
+/// Experimental `--containment` section, printed after the normal report.
+/// Lists small functions that are almost entirely copied into a larger one —
+/// duplication Jaccard misses because the larger body inflates the union. This
+/// is a separate finding from the clusters and is not part of the score.
+pub fn render_containment(report: &Report) -> String {
+    let mut out = String::new();
+    out.push('\n');
+    out.push_str(&bold("  CONTAINMENT  "));
+    out.push_str(&dim("(experimental · --containment)\n"));
+    out.push_str(&dim(
+        "  small functions copied into a larger one, which the score misses\n\n",
+    ));
+
+    if report.containment.is_empty() {
+        out.push_str("  No contained functions found.\n\n");
+        return out;
+    }
+
+    let loc = |file: &str, line: u32| format!("{file}:{line}");
+    let loc_width = report
+        .containment
+        .iter()
+        .flat_map(|c| {
+            [
+                loc(&c.contained.file, c.contained.start_line).len(),
+                loc(&c.container.file, c.container.start_line).len(),
+            ]
+        })
+        .max()
+        .unwrap_or(0)
+        .min(58);
+
+    for c in &report.containment {
+        let pct = format!("{:.0}%", c.containment * 100.0);
+        let title = format!(
+            "● {} ({} lines) is {} inside a larger function",
+            c.contained.name, c.contained.lines, pct,
+        );
+        out.push_str(&format!("  {}\n", bold(&title)));
+        let small_loc = truncate_left(&loc(&c.contained.file, c.contained.start_line), loc_width);
+        let large_loc = truncate_left(&loc(&c.container.file, c.container.start_line), loc_width);
+        out.push_str(&format!(
+            "    {} {small_loc:<loc_width$}  {}\n",
+            yellow("↳"),
+            dim("copied fragment"),
+        ));
+        out.push_str(&format!(
+            "      {large_loc:<loc_width$}  {}  {}\n",
+            c.container.name,
+            dim(&format!("{} lines", c.container.lines)),
+        ));
+        out.push('\n');
+    }
+    out.push_str(&dim(
+        "  experimental: containment ignores the larger body, so review before deleting\n",
+    ));
+    out
+}
+
 fn header(out: &mut String, r: &Report) {
     out.push('\n');
     out.push_str(&dim(&format!(

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -3,9 +3,11 @@
 
 use crate::cli::ScanArgs;
 use crate::cluster::{Cluster, build_clusters};
-use crate::config::{Config, DEFAULT_SCAN_THRESHOLD, MIN_SHARED_PREFILTER, TestPolicy};
+use crate::config::{
+    Config, DEFAULT_CONTAINMENT_THRESHOLD, DEFAULT_SCAN_THRESHOLD, MIN_SHARED_PREFILTER, TestPolicy,
+};
 use crate::extract::{FunctionUnit, analyze_source};
-use crate::index::find_pairs;
+use crate::index::{find_containment, find_pairs};
 use crate::report::{Report, Stats, build, terminal};
 use crate::score::slop_score;
 use crate::walk::{DiscoveredFile, discover, load};
@@ -25,6 +27,7 @@ pub struct ScanOutput {
 pub fn run(args: ScanArgs) -> Result<i32> {
     let mut config = Config::from_common(&args.common, DEFAULT_SCAN_THRESHOLD);
     config.include_classes = args.include_classes;
+    config.containment = args.containment;
     let output = scan_path(&args.path, &config)?;
 
     if let Some(cluster_id) = args.explain {
@@ -38,6 +41,9 @@ pub fn run(args: ScanArgs) -> Result<i32> {
         print!("{}", terminal::render(&output.report, args.all));
         if config.include_classes {
             print!("{}", terminal::render_shapes(&output.report));
+        }
+        if config.containment {
+            print!("{}", terminal::render_containment(&output.report));
         }
     }
 
@@ -167,6 +173,19 @@ pub fn scan_path(root: &Path, config: &Config) -> Result<ScanOutput> {
     if config.include_classes {
         report.class_shapes =
             crate::report::clusters_out(&shape_clusters, &shape_functions, &file_names);
+    }
+
+    // Experimental containment track: runs on the post-cull fingerprints left
+    // by find_pairs, surfacing small functions copied into a larger one that
+    // Jaccard alone misses. Never folded into the slop score.
+    if config.containment {
+        let pairs = find_containment(
+            &functions,
+            config.threshold,
+            DEFAULT_CONTAINMENT_THRESHOLD,
+            MIN_SHARED_PREFILTER,
+        );
+        report.containment = crate::report::containment_out(&pairs, &functions, &file_names);
     }
 
     Ok(ScanOutput {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -273,6 +273,7 @@ mod tests {
             tests: crate::config::TestPolicy::FlagOnly,
             json: false,
             include_classes: false,
+            containment: false,
         };
         let files = discover(root, &config).unwrap();
         let rels: Vec<&str> = files.iter().map(|f| f.rel.as_str()).collect();


### PR DESCRIPTION
Closes #7.

## What

Jaccard penalizes a small function pasted into a much larger one: the union grows with the big function while the intersection stays bounded by the small one, so the pair never reaches the similarity threshold and the copy stays invisible.

This adds an opt-in `--containment` track. Alongside the normal Jaccard scan it computes containment (shared / |smaller function|) and reports pairs above a strict 0.90 bar that the normal scan did not already cluster.

## Design

- Runs on the post-cull fingerprints left by the Jaccard pass, so language idiom is already filtered out.
- Experimental and opt-in, exactly like `--include-classes`: never folded into the slop score, and omitted from JSON when empty so default output is byte-for-byte unchanged.
- Drops pairs where one function is lexically nested inside the other (a closure inside its parent), since that overlap is structural rather than a copy.
- Reports the strongest container per contained function, sorted by the contained function's size, to keep the section low-noise.

## Example

A 10-line `validateUser` whose body is pasted into an 18-line `createAccount` in another file. The default scan grades it A and finds nothing; the union is dominated by `createAccount`.

```
  SLOP SCORE   0.0%   grade A

  No duplicate clusters found. Good dog.
```

With the flag:

```
  CONTAINMENT  (experimental, --containment)
  small functions copied into a larger one, which the score misses

  validateUser (10 lines) is 94% inside a larger function
    helper.ts:1   copied fragment
    handler.ts:1  createAccount  18 lines
```

## Tests

Three unit tests in `index.rs`: a small function reported inside a larger one, a lexically-nested pair skipped, and a near-identical pair left to the Jaccard scan. Full suite, clippy, and fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)