### PR TITLE
feat(lang): scaffold Clojure language registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
+ "tree-sitter-clojure-orchard",
  "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-java",
@@ -1123,6 +1124,16 @@ name = "tree-sitter-c-sharp"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-clojure-orchard"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b854ba5935d62a713280b867c09cae08c6ad2286895734b5550ed02122d8fd"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ unicode-width = "0.2.2"
 tree-sitter-c-sharp = "0.23.5"
 tree-sitter-kotlin-ng = "1.1.0"
 tree-sitter-scala = "0.26.0"
+tree-sitter-clojure-orchard = "0.2.8"
 
 [dev-dependencies]
 insta = { version = "1.47.2", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Prebuilt binaries for macOS, Linux and Windows are on the [releases page](https:
   <img src="assets/scan.png" alt="dupehound scan on the vscode source tree: 2.8 percent slop, grade A, listing the top duplicate clusters" width="880">
 </p>
 
-The slop score is the percentage of code you could delete if every cluster kept only one copy; the largest copy is exempt and test files are excluded by default, since table-driven tests are repetitive by design. On Rust, trait-impl methods (`From`, `Display`, ...) are also kept out of the score, since each impl is required and cannot be merged.
+The slop score is the percentage of code you could delete if every cluster kept only one copy; the largest copy is exempt and test files are excluded by default, since table-driven tests are repetitive by design. Methods whose name is required to match their siblings — Rust trait-impl methods (`From`, `Display`, ...) and Clojure `defmethod` dispatch branches — are also kept out of the score, since each is required and cannot be merged.
 
 <ul>
 <li><code>--explain N</code> prints a cluster's code as proof</li>
@@ -100,7 +100,7 @@ The slop score is the percentage of code you could delete if every cluster kept 
 <li><code>--containment</code> flags a small function copied into a larger one, which the Jaccard score misses because the larger body inflates the union (experimental, opt-in, never affects the slop score)</li>
 </ul>
 
-Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#, Kotlin, Scala.
+Languages: TypeScript, TSX, JavaScript, Python, Rust, Go, Java, Ruby, Swift, C, C++, PHP, C#, Kotlin, Scala, Clojure.
 
 ### `history`
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -18,9 +18,11 @@ pub struct Cluster {
     pub deletable_lines: u32,
     /// True when every member is test code.
     pub test_only: bool,
-    /// True when every member is a Rust trait-impl method (`From`, `Display`,
-    /// ...). Like `test_only`, these are kept out of the slop score: each impl
-    /// is a distinct, required implementation, not deletable duplication.
+    /// True when every member's name is required to match its siblings by
+    /// construction — a Rust trait-impl method (`From`, `Display`, ...) or a
+    /// Clojure `defmethod` dispatch branch. Like `test_only`, these are kept
+    /// out of the slop score: each is a distinct, required implementation,
+    /// not deletable duplication.
     pub trait_impl_only: bool,
 }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -30,9 +30,12 @@ pub struct FunctionUnit {
     /// Sorted, distinct winnowing fingerprints of the body.
     pub fingerprints: Vec<u64>,
     pub is_test: bool,
-    /// Rust only: a method inside an `impl Trait for Type` block. Every impl
-    /// of the same trait shares the method name (`from`, `fmt`, ...) by
-    /// definition, so these are near-duplicates that cannot be merged.
+    /// A method whose name is shared with its near-duplicate siblings by
+    /// construction, so the sharing is required rather than accidental and
+    /// the cluster can't be merged away: a Rust method inside an `impl
+    /// Trait for Type` block (every impl of the same trait shares the
+    /// method name — `from`, `fmt`, ...) or a Clojure `defmethod` dispatch
+    /// branch (every branch of the same multimethod shares its name).
     pub is_trait_impl_method: bool,
 }
 
@@ -88,6 +91,47 @@ fn is_rust_trait_impl_method(func: Node) -> bool {
     impl_item.kind() == "impl_item" && impl_item.child_by_field_name("trait").is_some()
 }
 
+/// The text of `list`'s head symbol, if its first value child is a plain
+/// symbol — the macro/function name a Clojure list form starts with, e.g.
+/// "defmethod" or "defrecord".
+fn clojure_list_head_text<'a>(list: Node, src: &'a str) -> Option<&'a str> {
+    let head = list.child_by_field_name("value")?;
+    if head.kind() != "sym_lit" {
+        return None;
+    }
+    head.child_by_field_name("name")?
+        .utf8_text(src.as_bytes())
+        .ok()
+}
+
+/// True if `func` is a Clojure `defmethod` form. Every defmethod for the
+/// same multimethod shares its `.name` (the multimethod name) by
+/// construction — one form per dispatch value — so near-duplicate dispatch
+/// branches can't be merged away. Same situation as `is_rust_trait_impl_method`
+/// above, reusing the same flag rather than inventing a Clojure-specific one.
+fn is_clojure_defmethod(func: Node, src: &str) -> bool {
+    clojure_list_head_text(func, src) == Some("defmethod")
+}
+
+/// True if `func`'s immediate parent is a defrecord/deftype/extend-type/
+/// extend-protocol/reify form -- a protocol method implementation, whose
+/// name is shared with every other type's implementation of the same
+/// method by construction. Same reasoning as `is_rust_trait_impl_method`
+/// and `is_clojure_defmethod`: reuses `is_trait_impl_method` rather than a
+/// third flag.
+fn is_clojure_protocol_method(func: Node, src: &str) -> bool {
+    let Some(parent) = func.parent() else {
+        return false;
+    };
+    if parent.kind() != "list_lit" {
+        return false;
+    }
+    matches!(
+        clojure_list_head_text(parent, src),
+        Some("defrecord" | "deftype" | "extend-type" | "extend-protocol" | "reify")
+    )
+}
+
 /// Extract and fingerprint every function in `src`. `file` is the caller's
 /// file id, stamped on each unit. `file_is_test` marks all units as test
 /// code; Rust additionally marks functions inside `#[cfg(test)]` regions.
@@ -138,7 +182,7 @@ pub fn analyze_source(
         let (Some(body), Some(func)) = (body, func) else {
             continue;
         };
-        let normalized = normalize(body);
+        let normalized = normalize(body, src.as_bytes());
         if normalized.codes.len() < min_tokens {
             continue;
         }
@@ -151,7 +195,13 @@ pub fn analyze_source(
             .unwrap_or("<anonymous>")
             .to_string();
         let is_test = file_is_test || test_boundary.is_some_and(|b| func.start_byte() as u32 >= b);
-        let is_trait_impl_method = lang == Lang::Rust && is_rust_trait_impl_method(func);
+        let is_trait_impl_method = match lang {
+            Lang::Rust => is_rust_trait_impl_method(func),
+            Lang::Clojure => {
+                is_clojure_defmethod(func, src) || is_clojure_protocol_method(func, src)
+            }
+            _ => false,
+        };
         functions.push(FunctionUnit {
             file,
             lang,
@@ -439,6 +489,316 @@ function describeUser(user: { name: string; age: number }): string {
         let fa1 = analyze_source(0, Lang::Typescript, without, 5, false).unwrap();
         let fa2 = analyze_source(0, Lang::Typescript, with, 5, false).unwrap();
         assert_eq!(fa1.functions[0].fingerprints, fa2.functions[0].fingerprints);
+    }
+
+    // Clojure's grammar represents operators, special forms, macros, and
+    // ordinary identifiers with the same `sym_name` node kind — unlike every
+    // other supported grammar, which gives keywords/operators their own
+    // distinct kinds separate from `identifier`. These two tests are the
+    // real regression guard for that: the TypeScript pair above proves
+    // normalization's core invariant once; this proves it still holds once
+    // a language can't lean on kind-name alone to tell "+" from "x".
+    const CLOJURE_PAIR: &str = r#"
+(defn sum-items [items factor]
+  (let [total (reduce (fn [acc item]
+                         (let [value (* (:price item) (:qty item))]
+                           (if (:discount item)
+                             (+ acc (* value (- 1.0 (:discount item))))
+                             (+ acc value))))
+                       0.0
+                       items)]
+    (+ total (* total factor))))
+
+(defn combine-totals [rows scale]
+  (let [sum (reduce (fn [acc row]
+                       (let [amount (* (:price row) (:qty row))]
+                         (if (:discount row)
+                           (+ acc (* amount (- 1.0 (:discount row))))
+                           (+ acc amount))))
+                     0.0
+                     rows)]
+    (+ sum (* sum scale))))
+"#;
+
+    #[test]
+    fn clojure_renamed_clone_has_identical_fingerprints() {
+        // Same shape, every local variable/parameter renamed, operators and
+        // special forms (defn, let, reduce, fn, if, +, *, -) untouched — a
+        // textbook type-2 clone.
+        let fa = analyze_source(0, Lang::Clojure, CLOJURE_PAIR, 10, false).unwrap();
+        assert_eq!(fa.functions.len(), 2);
+        assert_eq!(fa.functions[0].fingerprints, fa.functions[1].fingerprints);
+    }
+
+    #[test]
+    fn clojure_different_logic_does_not_match() {
+        // Same nesting shape, same literal-type pattern, but different verbs
+        // throughout (max/when/min/- instead of */if/+). Before TokenClass::Op
+        // exists, every symbol collapses to the same code regardless of kind,
+        // so this is expected to FAIL — it's the concrete proof the fix does
+        // what it claims once it lands.
+        let src = r#"
+(defn sum-items [items factor]
+  (let [total (reduce (fn [acc item]
+                         (let [value (* (:price item) (:qty item))]
+                           (if (:discount item)
+                             (+ acc (* value (- 1.0 (:discount item))))
+                             (+ acc value))))
+                       0.0
+                       items)]
+    (+ total (* total factor))))
+
+(defn max-items [items factor]
+  (let [total (reduce (fn [acc item]
+                         (let [value (max (:price item) (:qty item))]
+                           (when (:discount item)
+                             (- acc (min value (/ 1.0 (:discount item)))))
+                           (- acc value)))
+                       0.0
+                       items)]
+    (- total (/ total factor))))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 10, false).unwrap();
+        assert_eq!(fa.functions.len(), 2);
+        let j = crate::fingerprint::jaccard(
+            &fa.functions[0].fingerprints,
+            &fa.functions[1].fingerprints,
+        );
+        assert!(j < 0.3, "unrelated functions scored {j}");
+    }
+
+    #[test]
+    fn clojure_deftest_forms_are_captured() {
+        // clojure.test's `deftest` isn't literally `defn`, so it needs its
+        // own arm in the query's #any-of? list — without it, every deftest
+        // in a real codebase's test suite is invisible to dupehound.
+        let src = r#"
+(defn add-one [x]
+  (+ x 1))
+
+(deftest add-one-test
+  (testing "adds one"
+    (is (= 2 (add-one 1)))
+    (is (= 3 (add-one 2)))))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 5, false).unwrap();
+        let names: Vec<&str> = fa.functions.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["add-one", "add-one-test"]);
+    }
+
+    #[test]
+    fn clojure_def_bound_fn_is_captured() {
+        // (def name (fn [args] ...)) is the def+fn idiom, equivalent to
+        // (defn name [args] ...) -- mirrors javascript.scm's
+        // variable_declarator pattern for `const name = () => {...}`.
+        // len() == 1, not 2: dupehound intentionally has no bare/anonymous
+        // -fn pattern (same javascript.scm precedent -- arrow functions are
+        // only matched when bound to a name), so the inner (fn ...) node
+        // is captured exactly once, by this pattern alone.
+        let src = r#"
+(def add-one (fn [x]
+  (+ x 1)))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        assert_eq!(fa.functions.len(), 1);
+        assert_eq!(fa.functions[0].name, "add-one");
+    }
+
+    #[test]
+    fn clojure_plain_def_is_not_a_function() {
+        // (def x 5) and (def config {...}) bind data, not a function value
+        // -- only a def whose value is (fn ...) should match.
+        let src = r#"
+(def just-data
+  {:a 1 :b 2})
+
+(def aliased +)
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        assert!(
+            fa.functions.is_empty(),
+            "expected no functions, got {:?}",
+            fa.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn clojure_def_bound_fn_renamed_clone_has_identical_fingerprints() {
+        // Two def+fn functions, same shape, renamed variable/parameter --
+        // the def+fn idiom needs the same type-2-clone guarantee defn
+        // already has. (defn and def+fn are NOT expected to match each
+        // other: def+fn's body is just the inner (fn ...) node, so it has
+        // no equivalent to defn's own leading "defn"/name tokens -- they're
+        // different shapes, not the same stream.)
+        let src = r#"
+(def add-one (fn [x]
+  (+ x 1)))
+
+(def increment (fn [y]
+  (+ y 1)))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        assert_eq!(fa.functions.len(), 2);
+        assert_eq!(fa.functions[0].fingerprints, fa.functions[1].fingerprints);
+    }
+
+    #[test]
+    fn clojure_defmulti_and_defmethod_are_captured() {
+        let src = r#"
+(defmulti area (fn [shape] (:type shape)))
+
+(defmethod area :circle [shape]
+  (* Math/PI (:radius shape) (:radius shape)))
+
+(defmethod area :square [shape]
+  (* (:side shape) (:side shape)))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        let names: Vec<&str> = fa.functions.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["area", "area", "area"]);
+    }
+
+    #[test]
+    fn clojure_defmethod_is_flagged_like_a_trait_impl_method() {
+        // Mirrors rust_trait_impl_methods_are_flagged below: a plain defn
+        // and a defmethod dispatch branch. Only the defmethod is flagged --
+        // every dispatch branch of the same multimethod shares its name by
+        // construction, so near-duplicate branches can't be merged away,
+        // the same reasoning as a Rust trait impl.
+        let src = r#"
+(defn plain-area [shape]
+  (* (:side shape) (:side shape)))
+
+(defmethod area :circle [shape]
+  (* Math/PI (:radius shape) (:radius shape)))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        let plain = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "plain-area")
+            .unwrap();
+        let dispatch = fa.functions.iter().find(|f| f.name == "area").unwrap();
+        assert!(!plain.is_trait_impl_method);
+        assert!(dispatch.is_trait_impl_method);
+    }
+
+    #[test]
+    fn clojure_protocol_methods_are_captured() {
+        let src = r#"
+(defrecord DefaultShellExecutor []
+  ShellExecutor
+
+  (run-cmd [_this cmd args opts]
+    (assoc opts :cmd cmd)))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        assert_eq!(fa.functions.len(), 1);
+        assert_eq!(fa.functions[0].name, "run-cmd");
+    }
+
+    #[test]
+    fn clojure_protocol_method_renamed_clone_has_identical_fingerprints() {
+        // Two records implementing the same protocol method, same logic,
+        // renamed locals only -- the standard type-2-clone guarantee every
+        // other captured Clojure form already has.
+        let src = r#"
+(defrecord DefaultShellExecutor []
+  ShellExecutor
+
+  (run-cmd [_this cmd args opts]
+    (let [env-map (get opts :env {})]
+      (assoc opts :cmd cmd :env env-map))))
+
+(defrecord LoggingShellExecutor []
+  ShellExecutor
+
+  (run-cmd [_this command arguments options]
+    (let [env-vars (get options :env {})]
+      (assoc options :cmd command :env env-vars))))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        assert_eq!(fa.functions.len(), 2);
+        assert_eq!(fa.functions[0].fingerprints, fa.functions[1].fingerprints);
+    }
+
+    #[test]
+    fn clojure_protocol_method_is_flagged_like_a_trait_impl_method() {
+        // Mirrors clojure_defmethod_is_flagged_like_a_trait_impl_method: a
+        // plain defn isn't flagged, a protocol method implementation is --
+        // its name is shared with every other type's implementation of the
+        // same method by construction.
+        let src = r#"
+(defn plain-run [cmd]
+  (assoc {} :cmd cmd))
+
+(defrecord DefaultShellExecutor []
+  ShellExecutor
+
+  (run-cmd [_this cmd args opts]
+    (assoc opts :cmd cmd)))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        let plain = fa.functions.iter().find(|f| f.name == "plain-run").unwrap();
+        let method = fa.functions.iter().find(|f| f.name == "run-cmd").unwrap();
+        assert!(!plain.is_trait_impl_method);
+        assert!(method.is_trait_impl_method);
+    }
+
+    #[test]
+    fn clojure_vector_arg_call_is_not_a_protocol_method() {
+        // The concrete false-positive guard: (zipmap [:a :b] [1 2]) is
+        // shaped exactly like a protocol method -- symbol, then a vector --
+        // but it's nested inside caller's own body, not a direct child of a
+        // defrecord/deftype/.../reify form, so it must not match.
+        let src = r#"
+(defn caller []
+  (zipmap [:a :b] [1 2]))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        let names: Vec<&str> = fa.functions.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["caller"]);
+    }
+
+    #[test]
+    fn clojure_extend_type_extend_protocol_and_reify_methods_are_captured() {
+        let src = r#"
+(extend-type MyType
+  ShellExecutor
+  (run-cmd [this cmd args opts]
+    (do-thing cmd)))
+
+(extend-protocol ShellExecutor
+  AnotherType
+  (run-cmd [this cmd args opts]
+    (do-thing cmd))
+  ThirdType
+  (run-cmd [this cmd args opts]
+    (do-other cmd)))
+
+(defn make-inline-executor []
+  (reify ShellExecutor
+    (run-cmd [this cmd args opts]
+      (do-thing cmd))))
+"#;
+        let fa = analyze_source(0, Lang::Clojure, src, 1, false).unwrap();
+        // extend-type: 1 run-cmd, extend-protocol: 2 (AnotherType + ThirdType),
+        // reify: 1 run-cmd -- plus make-inline-executor itself, the ordinary
+        // defn that wraps the reify expression.
+        let run_cmds: Vec<_> = fa
+            .functions
+            .iter()
+            .filter(|f| f.name == "run-cmd")
+            .collect();
+        assert_eq!(run_cmds.len(), 4);
+        assert!(run_cmds.iter().all(|f| f.is_trait_impl_method));
+        let wrapper = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "make-inline-executor")
+            .unwrap();
+        assert!(!wrapper.is_trait_impl_method);
+        assert_eq!(fa.functions.len(), 5);
     }
 
     const CS_CLASSES: &str = r#"

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -1,5 +1,5 @@
 use std::sync::OnceLock;
-use tree_sitter::{Language, Query};
+use tree_sitter::{Language, Node, Query};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -19,10 +19,11 @@ pub enum Lang {
     Csharp,
     Kotlin,
     Scala,
+    Clojure,
 }
 
 #[cfg(test)]
-pub const ALL: [Lang; 15] = [
+pub const ALL: [Lang; 16] = [
     Lang::Typescript,
     Lang::Tsx,
     Lang::Javascript,
@@ -38,6 +39,7 @@ pub const ALL: [Lang; 15] = [
     Lang::Csharp,
     Lang::Kotlin,
     Lang::Scala,
+    Lang::Clojure,
 ];
 
 impl Lang {
@@ -59,6 +61,7 @@ impl Lang {
             "cs" => Some(Lang::Csharp),
             "kt" | "kts" => Some(Lang::Kotlin),
             "scala" | "sc" => Some(Lang::Scala),
+            "clj" | "cljc" | "cljs" => Some(Lang::Clojure),
             _ => None,
         }
     }
@@ -80,6 +83,7 @@ impl Lang {
             Lang::Csharp => "C#",
             Lang::Kotlin => "Kotlin",
             Lang::Scala => "Scala",
+            Lang::Clojure => "Clojure",
         }
     }
 
@@ -100,6 +104,7 @@ impl Lang {
             Lang::Csharp => tree_sitter_c_sharp::LANGUAGE.into(),
             Lang::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
             Lang::Scala => tree_sitter_scala::LANGUAGE.into(),
+            Lang::Clojure => tree_sitter_clojure_orchard::LANGUAGE.into(),
         }
     }
 
@@ -119,11 +124,12 @@ impl Lang {
             Lang::Csharp => include_str!("queries/csharp.scm"),
             Lang::Kotlin => include_str!("queries/kotlin.scm"),
             Lang::Scala => include_str!("queries/scala.scm"),
+            Lang::Clojure => include_str!("queries/clojure.scm"),
         }
     }
 
     pub fn query(self) -> &'static Query {
-        static QUERIES: [OnceLock<Query>; 15] = [const { OnceLock::new() }; 15];
+        static QUERIES: [OnceLock<Query>; 16] = [const { OnceLock::new() }; 16];
         QUERIES[self as usize].get_or_init(|| {
             Query::new(&self.language(), self.query_source())
                 .unwrap_or_else(|e| panic!("bad {} query: {e}", self.name()))
@@ -141,7 +147,7 @@ impl Lang {
 
     pub fn shape_query(self) -> Option<&'static Query> {
         let src = self.shape_query_source()?;
-        static SHAPE_QUERIES: [OnceLock<Query>; 15] = [const { OnceLock::new() }; 15];
+        static SHAPE_QUERIES: [OnceLock<Query>; 16] = [const { OnceLock::new() }; 16];
         Some(SHAPE_QUERIES[self as usize].get_or_init(|| {
             Query::new(&self.language(), src)
                 .unwrap_or_else(|e| panic!("bad {} shape query: {e}", self.name()))
@@ -162,14 +168,34 @@ pub enum TokenClass {
     Comment,
     /// Structure (keywords, operators, punctuation): kept verbatim by kind id.
     Other,
+    /// Operator/special-form/macro symbol in a grammar too coarse to give it
+    /// its own node kind (e.g. Clojure's `sym_name`, used for `+`, `if`,
+    /// `reduce` and ordinary identifiers alike): kept verbatim by hashed
+    /// text, since kind id alone can't distinguish it from an identifier.
+    Op,
 }
 
-/// Classify a leaf node kind name. Kind-name conventions are consistent
-/// enough across the bundled grammars that substring rules beat per-grammar
-/// tables — and they survive grammar upgrades better.
-pub fn classify(kind: &str) -> TokenClass {
+/// Classify a leaf node. Kind-name conventions are consistent enough across
+/// the bundled grammars that substring rules on `leaf.kind()` beat
+/// per-grammar tables for almost everything — and they survive grammar
+/// upgrades better.
+///
+/// Clojure is the exception: its `sym_name` node covers call heads, special
+/// forms, macros, functions, and local variables alike, so kind name alone
+/// can't separate "operator" from "identifier" the way every other
+/// supported grammar's node kinds do. `is_clojure_call_head` breaks the tie
+/// using the leaf's position instead — hence this function takes the whole
+/// `Node`, not just its kind string.
+pub fn classify(leaf: Node) -> TokenClass {
+    let kind = leaf.kind();
     if kind.contains("comment") {
         TokenClass::Comment
+    } else if kind == "sym_name" {
+        if leaf.parent().is_some_and(is_clojure_call_head) {
+            TokenClass::Op
+        } else {
+            TokenClass::Ident
+        }
     } else if kind.contains("identifier") || kind == "shorthand_property_identifier_pattern" {
         TokenClass::Ident
     } else if kind.contains("string")
@@ -177,6 +203,8 @@ pub fn classify(kind: &str) -> TokenClass {
         || kind.contains("rune")
         || kind == "escape_sequence"
         || kind == "template_chars"
+        || kind == "str_lit"
+        || kind == "kwd_name"
         || kind == "\""
         || kind == "'"
         || kind == "`"
@@ -188,11 +216,30 @@ pub fn classify(kind: &str) -> TokenClass {
         || kind.contains("decimal")
         || kind.contains("imaginary")
         || kind == "int_literal"
+        || kind == "num_lit"
     {
         TokenClass::Num
     } else {
         TokenClass::Other
     }
+}
+
+/// True if `sym_lit` occupies the head (first) position of a Clojure list
+/// form — `(reduce ...)`, `(if ...)`, `(+ ...)` — meaning the symbol names
+/// the operator/special-form/macro being invoked rather than referencing a
+/// bound value. Deliberately Clojure-grammar-specific (it names
+/// `list_lit`/`value` directly): a second Lisp dialect should get its own
+/// version of this function against its own grammar's node shape, not a
+/// generalization of this one.
+fn is_clojure_call_head(sym_lit: Node) -> bool {
+    let Some(list) = sym_lit.parent() else {
+        return false;
+    };
+    if list.kind() != "list_lit" {
+        return false;
+    }
+    list.child_by_field_name("value")
+        .is_some_and(|first| first.id() == sym_lit.id())
 }
 
 #[cfg(test)]

--- a/src/lang/queries/clojure.scm
+++ b/src/lang/queries/clojure.scm
@@ -1,0 +1,45 @@
+(list_lit
+  .
+  (sym_lit name: (sym_name) @_kw)
+  .
+  (sym_lit name: (sym_name) @name)
+  .
+  (#any-of? @_kw "defn" "defn-" "defmacro" "deftest" "defmulti" "defmethod")) @func @body
+
+; (def name (fn [args] ...)) -- a function value bound via def instead of
+; defn. Mirrors javascript.scm's variable_declarator pattern: only fn-valued
+; defs match, so a bare (def x 5) or (def config {...}) is left alone. @body
+; is the inner (fn ...) form, not the whole def -- unlike defn, def actually
+; has a distinct value node to point at, so there's no need to fall back to
+; "the whole form is the body" here.
+(list_lit
+  .
+  (sym_lit name: (sym_name) @_kw)
+  .
+  (sym_lit name: (sym_name) @name)
+  .
+  (list_lit
+    .
+    (sym_lit name: (sym_name) @_fnkw)
+    .
+    (#eq? @_fnkw "fn")) @body
+  (#eq? @_kw "def")) @func
+
+; Protocol method implementations inside defrecord/deftype/extend-type/
+; extend-protocol/reify. No keyword of their own -- the method's own name
+; is the list's head -- so the only way to distinguish one from an
+; ordinary function call shaped the same way (symbol, then a vector
+; argument, e.g. (zipmap [:a :b] [1 2])) is position: it must be a direct
+; child of one of these five forms. Nesting in this query mirrors direct
+; parent-child structure in the tree, so a call like that buried inside
+; some other function's body can never match here.
+(list_lit
+  .
+  (sym_lit name: (sym_name) @_defkw)
+  .
+  (#any-of? @_defkw "defrecord" "deftype" "extend-type" "extend-protocol" "reify")
+  (list_lit
+    .
+    (sym_lit name: (sym_name) @name)
+    .
+    (vec_lit)) @func @body)

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -4,12 +4,33 @@
 //! grammar kind id verbatim.
 
 use crate::lang::{TokenClass, classify};
+use rustc_hash::FxHasher;
+use std::hash::{Hash, Hasher};
 use tree_sitter::Node;
 
 /// Sentinel codes live above any real grammar kind id.
 pub const ID: u16 = u16::MAX;
 pub const STR: u16 = u16::MAX - 1;
 pub const NUM: u16 = u16::MAX - 2;
+
+/// Band reserved for `TokenClass::Op` codes: hashed leaf text, not a grammar
+/// kind id. Sits just below the three sentinels, far above any realistic
+/// grammar's kind id count, so it can't collide with either. Dialect-agnostic
+/// — any future language whose `classify()` returns `Op` reuses this
+/// unchanged; only Clojure's `classify()` branch currently produces it.
+const OP_BASE: u16 = u16::MAX - 4099;
+const OP_BAND: u16 = 4096;
+
+/// Code for an `Op`-classified leaf: same text always hashes to the same
+/// code, so `+` still means `+` everywhere it's the head of a Clojure form.
+/// Collisions inside the band are possible (birthday bound, ~4096 buckets)
+/// but low-impact — functions are only ever compared within the same
+/// language, and matching is already a lossy winnowed sketch.
+fn op_code(text: &str) -> u16 {
+    let mut h = FxHasher::default();
+    text.hash(&mut h);
+    OP_BASE + (h.finish() as u16 % OP_BAND)
+}
 
 pub struct Normalized {
     pub codes: Vec<u16>,
@@ -20,14 +41,15 @@ pub struct Normalized {
 /// Normalize the leaves of `node`. A single literal can span several leaf
 /// tokens (open quote, content, escapes, close quote), so consecutive equal
 /// literal sentinels are collapsed into one code — `"a${x}b"` becomes
-/// STR ID STR rather than STR STR ID STR STR.
-pub fn normalize(node: Node) -> Normalized {
+/// STR ID STR rather than STR STR ID STR STR. `src` is the whole file's
+/// bytes; only `Op`-classified leaves need it, to hash their text.
+pub fn normalize(node: Node, src: &[u8]) -> Normalized {
     let mut codes: Vec<u16> = Vec::with_capacity(256);
     let mut sig_lines = 0u32;
     let mut last_line = u32::MAX;
 
     visit_leaves(node, &mut |leaf| {
-        let class = classify(leaf.kind());
+        let class = classify(leaf);
         if class == TokenClass::Comment {
             return;
         }
@@ -42,6 +64,7 @@ pub fn normalize(node: Node) -> Normalized {
             TokenClass::Num => NUM,
             TokenClass::Comment => unreachable!(),
             TokenClass::Other => leaf.kind_id(),
+            TokenClass::Op => op_code(leaf.utf8_text(src).unwrap_or("")),
         };
         let collapsible = code == STR || code == NUM;
         if collapsible && codes.last() == Some(&code) {
@@ -59,7 +82,7 @@ pub fn significant_lines(node: Node) -> u32 {
     let mut count = 0u32;
     let mut last_line = u32::MAX;
     visit_leaves(node, &mut |leaf| {
-        if classify(leaf.kind()) == TokenClass::Comment {
+        if classify(leaf) == TokenClass::Comment {
             return;
         }
         let row = leaf.start_position().row as u32;
@@ -87,6 +110,33 @@ fn visit_leaves(node: Node, f: &mut impl FnMut(Node)) {
             if !cursor.goto_parent() {
                 break 'outer;
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn op_code_is_deterministic() {
+        assert_eq!(op_code("+"), op_code("+"));
+        assert_eq!(op_code("reduce"), op_code("reduce"));
+    }
+
+    #[test]
+    fn op_code_stays_inside_the_reserved_band_and_off_the_sentinels() {
+        for text in [
+            "+", "-", "*", "/", "if", "when", "let", "reduce", "filter", "map", "defn",
+        ] {
+            let code = op_code(text);
+            assert!(
+                (OP_BASE..OP_BASE + OP_BAND).contains(&code),
+                "{text} coded to {code}, outside the reserved band"
+            );
+            assert_ne!(code, ID);
+            assert_ne!(code, STR);
+            assert_ne!(code, NUM);
         }
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -55,8 +55,9 @@ pub struct ClusterOut {
     pub similarity: f64,
     pub deletable_lines: u32,
     pub test_only: bool,
-    /// Rust trait-impl look-alikes (`From`/`Display`/...), kept out of the
-    /// slop score. Omitted when false so existing output is unchanged.
+    /// Required-name look-alikes (Rust trait impls, Clojure `defmethod`
+    /// dispatch branches), kept out of the slop score. Omitted when false so
+    /// existing output is unchanged.
     #[serde(default, skip_serializing_if = "is_false")]
     pub trait_impl_only: bool,
     pub members: Vec<MemberOut>,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -108,7 +108,7 @@ pub fn discover(root: &Path, config: &Config) -> Result<Vec<DiscoveredFile>> {
     if files.is_empty() {
         anyhow::bail!(
             "no supported source files found under {} \
-             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb .swift .c .h .cpp .cc .hpp .php .cs .kt .kts .scala .sc)",
+             (supported: .ts .tsx .js .jsx .py .rs .go .java .rb .swift .c .h .cpp .cc .hpp .php .cs .kt .kts .scala .sc .clj .cljc .cljs)",
             root.display()
         );
     }

--- a/tests/languages.rs
+++ b/tests/languages.rs
@@ -570,6 +570,34 @@ pub fn chunk_entries(text: &str, delim: char) -> Vec<String> {
 "#,
 };
 
+const CLOJURE: Fixture = Fixture {
+    file_a: "billing.clj",
+    file_b: "invoices.clj",
+    names: ("compute-total", "calculate-amount"),
+    src_a: r#"
+(defn compute-total [items tax-rate]
+  (let [subtotal (reduce (fn [acc item]
+                            (let [price (* (:price item) (:qty item))]
+                              (if (:discount item)
+                                (+ acc (* price (- 1.0 (:discount item))))
+                                (+ acc price))))
+                          0.0
+                          items)]
+    (+ subtotal (* subtotal tax-rate))))
+"#,
+    src_b: r#"
+(defn calculate-amount [rows vat]
+  (let [base-amount (reduce (fn [acc row]
+                               (let [cost (* (:price row) (:qty row))]
+                                 (if (:discount row)
+                                   (+ acc (* cost (- 1.0 (:discount row))))
+                                   (+ acc cost))))
+                             0.0
+                             rows)]
+    (+ base-amount (* base-amount vat))))
+"#,
+};
+
 fn run_scan_json(fixture: &Fixture) -> serde_json::Value {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join(fixture.file_a), fixture.src_a).unwrap();
@@ -650,6 +678,11 @@ fn ruby_renamed_clone_is_detected() {
 #[test]
 fn rust_renamed_clone_is_detected() {
     assert_clone_pair_detected(&RUST);
+}
+
+#[test]
+fn clojure_renamed_clone_is_detected() {
+    assert_clone_pair_detected(&CLOJURE);
 }
 
 #[test]


### PR DESCRIPTION
Registers Lang::Clojure end to end: grammar crate, extension mapping,
the defn/defn-/defmacro query, and the str_lit/num_lit literal-kind
fixes classify() needs for this grammar's node names.

Uses tree-sitter-clojure-orchard rather than tree-sitter-clojure: the
latter pins tree-sitter ^0.25.6, which conflicts with this project's
tree-sitter (a links = "tree-sitter" native crate, so only one version
can appear in the graph). orchard depends only on the ABI-stable
tree-sitter-language shim and exposes byte-identical node/field names
(list_lit/sym_lit/sym_name/str_lit/num_lit/kwd_lit, value/name fields),
so nothing else about the design changes.

This is scaffolding only — no TokenClass::Op / position-aware symbol
classification yet, so Clojure functions that differ only in which
operators/special forms they call will currently still cluster as
false positives. That's the next piece of work, test-first per the
extract.rs core-behavior pattern (see the design spec).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>